### PR TITLE
[Feat] 고객의 보유 주식을 보여주는 화면 & 담보로 잡은 주식을 보여주는 화면

### DIFF
--- a/frontend/src/components/button/ButtonBar.tsx
+++ b/frontend/src/components/button/ButtonBar.tsx
@@ -8,6 +8,8 @@ interface ButtonProps {
   beforeurl: string;
   nextdisabled?: boolean;
   beforedisabled?: boolean;
+  beforestate?: any;
+  nextstate?: any;
 }
 
 export default function ButtonBar({
@@ -17,8 +19,26 @@ export default function ButtonBar({
   beforeurl,
   nextdisabled,
   beforedisabled,
+  beforestate,
+  nextstate,
 }: ButtonProps) {
   const navigate = useNavigate();
+
+  const moveToBefore = () => {
+    if (beforestate !== undefined) {
+      navigate(beforeurl, { state: beforestate });
+    } else {
+      navigate(beforeurl);
+    }
+  };
+
+  const moveToNext = () => {
+    if (nextstate !== undefined) {
+      navigate(nexturl, { state: nextstate });
+    } else {
+      navigate(nexturl);
+    }
+  };
 
   return (
     <div
@@ -28,14 +48,16 @@ export default function ButtonBar({
       <BasicButton
         type="gray"
         disabled={beforedisabled}
-        onClick={() => navigate(beforeurl)}
+        //onClick={() => navigate(beforeurl)}
+        onClick={moveToBefore}
       >
         {beforetext}
       </BasicButton>
       <BasicButton
         type="blue"
         disabled={nextdisabled}
-        onClick={() => navigate(nexturl)}
+        //onClick={() => navigate(nexturl)}
+        onClick={moveToNext}
       >
         {nexttext}
       </BasicButton>

--- a/frontend/src/components/button/MoveButton.tsx
+++ b/frontend/src/components/button/MoveButton.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import styled from "styled-components";
+
+interface ButtonProps {
+  children: React.ReactNode;
+  onClick?: () => void;
+}
+
+const StyledButton = styled.button<ButtonProps>`
+  //width: 30%;
+  padding: "8px 16px";
+  border: none;
+  border-radius: 7px;
+  font-size: 15px;
+  color: black;
+  background-color: white;
+  cursor: pointer;
+  box-shadow: 1px 2px 3px rgba(0, 0, 0, 0.1);
+
+  &:hover {
+    opacity: 0.9;
+  }
+
+  &:disabled {
+    background-color: #f8f8f8;
+    cursor: not-allowed;
+  }
+`;
+
+export default function MoveButton({ children, onClick }: ButtonProps) {
+  return <StyledButton onClick={onClick}>{children}</StyledButton>;
+}

--- a/frontend/src/main-router.tsx
+++ b/frontend/src/main-router.tsx
@@ -12,6 +12,7 @@ import ServiceAgreePage from "./routes/agree/ServiceAgreePage";
 import StockCheckPage from "./routes/stockcheck/StockCheckPage";
 import SelectedStockPage from "./routes/selectedstock/SelectedStockPage";
 import PriorityPage from "./routes/priority/PriorityPage";
+import SettingLimitPage from "./routes/settinglimit/SettingLimitPage";
 
 const routers = [
   {
@@ -90,6 +91,10 @@ const routers = [
   {
     path: "/priority",
     element: <PriorityPage />,
+  },
+  {
+    path: "/limit",
+    element: <SettingLimitPage />,
   },
 ];
 

--- a/frontend/src/main-router.tsx
+++ b/frontend/src/main-router.tsx
@@ -10,6 +10,8 @@ import AllmenuPage from "./routes/allmenu/AllmenuPage";
 import AssetPage from "./routes/asset/AssetPage";
 import ServiceAgreePage from "./routes/agree/ServiceAgreePage";
 import StockCheckPage from "./routes/stockcheck/StockCheckPage";
+import SelectedStockPage from "./routes/selectedstock/SelectedStockPage";
+import PriorityPage from "./routes/priority/PriorityPage";
 
 const routers = [
   {
@@ -45,10 +47,6 @@ const routers = [
     ],
   },
   {
-    path: "/stockcheck",
-    element: <StockCheckPage />,
-  },
-  {
     path: "/payment",
     element: <MenubarLayout />,
     children: [
@@ -80,6 +78,18 @@ const routers = [
         index: true,
       },
     ],
+  },
+  {
+    path: "/stockcheck",
+    element: <StockCheckPage />,
+  },
+  {
+    path: "/selectedstock",
+    element: <SelectedStockPage />,
+  },
+  {
+    path: "/priority",
+    element: <PriorityPage />,
   },
 ];
 

--- a/frontend/src/main-router.tsx
+++ b/frontend/src/main-router.tsx
@@ -9,10 +9,9 @@ import PaymentPage from "./routes/payment/PaymentPage";
 import AllmenuPage from "./routes/allmenu/AllmenuPage";
 import AssetPage from "./routes/asset/AssetPage";
 import ServiceAgreePage from "./routes/agree/ServiceAgreePage";
-import StockCheckPage from "./routes/stockcheck/StockCheckPage";
-import SelectedStockPage from "./routes/selectedstock/SelectedStockPage";
 import PriorityPage from "./routes/priority/PriorityPage";
 import SettingLimitPage from "./routes/settinglimit/SettingLimitPage";
+import StockPage from "./routes/stock/StockPage";
 
 const routers = [
   {
@@ -81,13 +80,17 @@ const routers = [
     ],
   },
   {
-    path: "/stockcheck",
-    element: <StockCheckPage />,
+    path: "/stock",
+    element: <StockPage />,
   },
-  {
-    path: "/selectedstock",
-    element: <SelectedStockPage />,
-  },
+  // {
+  //   path: "/stockcheck",
+  //   element: <StockCheckPage />,
+  // },
+  // {
+  //   path: "/selectedstock",
+  //   element: <SelectedStockPage />,
+  // },
   {
     path: "/priority",
     element: <PriorityPage />,

--- a/frontend/src/routes/agree/ServiceAgreePage.tsx
+++ b/frontend/src/routes/agree/ServiceAgreePage.tsx
@@ -14,7 +14,7 @@ export default function ServiceAgreePage() {
         </AgreeFrame>
       </div>
       <ButtonBar
-        nexturl="/stockcheck"
+        nexturl="/stock"
         beforeurl="/main"
         nexttext="동의"
         beforetext="비동의"

--- a/frontend/src/routes/priority/PriorityPage.tsx
+++ b/frontend/src/routes/priority/PriorityPage.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useLocation } from "react-router-dom";
 import PaddingDiv from "../../components/settingdiv/PaddingDiv";
 import NormalTitle from "../../components/text/NormalTitle";
@@ -43,8 +42,8 @@ export default function PriorityPage() {
       <ButtonBar
         beforetext="이전"
         nexttext="다음"
-        beforeurl="/stockcheck"
-        beforestate={{ priorityToCheck: selectedStock }}
+        beforeurl="/stock"
+        beforestate={{ priorityToStock: selectedStock }}
         nexturl="/limit"
         nextstate={{ stocks: stocks }}
       />

--- a/frontend/src/routes/priority/PriorityPage.tsx
+++ b/frontend/src/routes/priority/PriorityPage.tsx
@@ -1,0 +1,5 @@
+import PaddingDiv from "../../components/settingdiv/PaddingDiv";
+
+export default function PriorityPage() {
+  return <PaddingDiv>this is 우선순위 페이지</PaddingDiv>;
+}

--- a/frontend/src/routes/priority/PriorityPage.tsx
+++ b/frontend/src/routes/priority/PriorityPage.tsx
@@ -8,17 +8,23 @@ export default function PriorityPage() {
   const location = useLocation();
 
   const { selectedStock } = location.state as {
-    selectedStock: [string, string, number, number, number][];
+    selectedStock: [
+      string,
+      string,
+      string,
+      string,
+      number,
+      number,
+      number,
+      number,
+      string
+    ][];
   };
 
-  const { stocks } = location.state as {
-    stocks: [string, string, number, number, number][];
-  };
-
-  let nowLimit: number = 0;
+  let limit: number = 0;
   for (let i = 0; i < selectedStock.length; i++) {
-    if (selectedStock[i][2] != 0) {
-      nowLimit += selectedStock[i][4] * selectedStock[i][2];
+    if (selectedStock[i][5] != 0) {
+      limit += selectedStock[i][5] * selectedStock[i][7];
     }
   }
 
@@ -27,7 +33,7 @@ export default function PriorityPage() {
       <div>
         <NormalTitle>
           현재 확보한 총 한도는
-          <span className="font-bold text-blue-700"> {nowLimit}원</span> 입니다.
+          <span className="font-bold text-blue-700"> {limit}원</span> 입니다.
         </NormalTitle>
         <div className="text-sm	text-gray-400">
           + 버튼을 통해 반대매매 시 우선으로 처리할 증권을 추가해보세요.
@@ -45,7 +51,7 @@ export default function PriorityPage() {
         beforeurl="/stock"
         beforestate={{ priorityToStock: selectedStock }}
         nexturl="/limit"
-        nextstate={{ stocks: stocks }}
+        nextstate={{ stock: selectedStock }}
       />
     </PaddingDiv>
   );

--- a/frontend/src/routes/priority/PriorityPage.tsx
+++ b/frontend/src/routes/priority/PriorityPage.tsx
@@ -1,5 +1,53 @@
+import { useState } from "react";
+import { useLocation } from "react-router-dom";
 import PaddingDiv from "../../components/settingdiv/PaddingDiv";
+import NormalTitle from "../../components/text/NormalTitle";
+import ButtonBar from "../../components/button/ButtonBar";
+import { IoAddCircle } from "react-icons/io5";
 
 export default function PriorityPage() {
-  return <PaddingDiv>this is 우선순위 페이지</PaddingDiv>;
+  const location = useLocation();
+
+  const { selectedStock } = location.state as {
+    selectedStock: [string, string, number, number, number][];
+  };
+
+  const { stocks } = location.state as {
+    stocks: [string, string, number, number, number][];
+  };
+
+  let nowLimit: number = 0;
+  for (let i = 0; i < selectedStock.length; i++) {
+    if (selectedStock[i][2] != 0) {
+      nowLimit += selectedStock[i][4] * selectedStock[i][2];
+    }
+  }
+
+  return (
+    <PaddingDiv>
+      <div>
+        <NormalTitle>
+          현재 확보한 총 한도는
+          <span className="font-bold text-blue-700"> {nowLimit}원</span> 입니다.
+        </NormalTitle>
+        <div className="text-sm	text-gray-400">
+          + 버튼을 통해 반대매매 시 우선으로 처리할 증권을 추가해보세요.
+        </div>
+        <div className="flex justify-center">
+          <IoAddCircle className="size-32 text-gray-400" />
+        </div>
+      </div>
+
+      <div>{selectedStock}</div>
+
+      <ButtonBar
+        beforetext="이전"
+        nexttext="다음"
+        beforeurl="/stockcheck"
+        beforestate={{ priorityToCheck: selectedStock }}
+        nexturl="/limit"
+        nextstate={{ stocks: stocks }}
+      />
+    </PaddingDiv>
+  );
 }

--- a/frontend/src/routes/selectedstock/SelectedStockPage.tsx
+++ b/frontend/src/routes/selectedstock/SelectedStockPage.tsx
@@ -1,0 +1,16 @@
+import ButtonBar from "../../components/button/ButtonBar";
+import PaddingDiv from "../../components/settingdiv/PaddingDiv";
+
+export default function SelectedStockPage() {
+  return (
+    <PaddingDiv>
+      this is selected stock page!
+      <ButtonBar
+        beforetext="이전"
+        nexttext="완료"
+        beforeurl="/stockcheck"
+        nexturl="/priority"
+      />
+    </PaddingDiv>
+  );
+}

--- a/frontend/src/routes/selectedstock/SelectedStockPage.tsx
+++ b/frontend/src/routes/selectedstock/SelectedStockPage.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import ButtonBar from "../../components/button/ButtonBar";
 import PaddingDiv from "../../components/settingdiv/PaddingDiv";
 import NormalTitle from "../../components/text/NormalTitle";
+import BackgroundFrame from "../../components/backgroundframe/BackgroundFrame";
 
 export default function SelectedStockPage() {
   //const navigate = useNavigate();
@@ -11,23 +12,48 @@ export default function SelectedStockPage() {
   const { selectedStock } = location.state as {
     selectedStock: [string, string, number, number, number][];
   };
-  const [gotStock, setGotStock] =
-    useState<[string, string, number, number, number][]>(selectedStock);
 
   const [updatedStock, setUpdatedStock] =
     useState<[string, string, number, number, number][]>(selectedStock);
 
+  useEffect(() => {
+    console.log(selectedStock);
+  }, [selectedStock]);
+
+  const [nowLimit, setNowLimit] = useState<number>(() => {
+    let totalLimit = 0;
+    for (let i = 0; i < selectedStock.length; i++) {
+      if (selectedStock[i][2] != 0) {
+        totalLimit += selectedStock[i][4] * selectedStock[i][2];
+      }
+    }
+    return totalLimit;
+  });
+
   return (
     <PaddingDiv>
       <NormalTitle>
-        현재 확보한 총 한도는{" "}
-        <span className="font-bold text-blue-700">1000000원</span> 입니다.
+        현재 확보한 총 한도는
+        <span className="font-bold text-blue-700"> {nowLimit}원</span> 입니다.
+        <div className="text-sm	text-gray-400">
+          종목을 클릭하면 수정 또는 삭제가 가능합니다.
+        </div>
       </NormalTitle>
+      <div className="flex flex-col">
+        <NormalTitle>선택한 주식</NormalTitle>
+        <BackgroundFrame color="blue">
+          <div>여기 선택한 주식</div>
+        </BackgroundFrame>
+        <NormalTitle>선택 안 한 주식</NormalTitle>
+        <BackgroundFrame color="blue">
+          <div>여기 선택 안한 주식</div>
+        </BackgroundFrame>
+      </div>
       <ButtonBar
         beforetext="이전"
         nexttext="완료"
         beforeurl="/stockcheck"
-        beforestate={{ gotStock: gotStock }}
+        beforestate={{ gotStock: selectedStock }}
         nexturl="/priority"
         nextstate={{ updatedStock: updatedStock }}
       />

--- a/frontend/src/routes/selectedstock/SelectedStockPage.tsx
+++ b/frontend/src/routes/selectedstock/SelectedStockPage.tsx
@@ -1,8 +1,22 @@
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import ButtonBar from "../../components/button/ButtonBar";
 import PaddingDiv from "../../components/settingdiv/PaddingDiv";
 import NormalTitle from "../../components/text/NormalTitle";
 
 export default function SelectedStockPage() {
+  //const navigate = useNavigate();
+  const location = useLocation();
+
+  const { selectedStock } = location.state as {
+    selectedStock: [string, string, number, number, number][];
+  };
+  const [gotStock, setGotStock] =
+    useState<[string, string, number, number, number][]>(selectedStock);
+
+  const [updatedStock, setUpdatedStock] =
+    useState<[string, string, number, number, number][]>(selectedStock);
+
   return (
     <PaddingDiv>
       <NormalTitle>
@@ -13,7 +27,9 @@ export default function SelectedStockPage() {
         beforetext="이전"
         nexttext="완료"
         beforeurl="/stockcheck"
+        beforestate={{ gotStock: gotStock }}
         nexturl="/priority"
+        nextstate={{ updatedStock: updatedStock }}
       />
     </PaddingDiv>
   );

--- a/frontend/src/routes/selectedstock/SelectedStockPage.tsx
+++ b/frontend/src/routes/selectedstock/SelectedStockPage.tsx
@@ -1,96 +1,96 @@
-import { useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
-import ButtonBar from "../../components/button/ButtonBar";
-import PaddingDiv from "../../components/settingdiv/PaddingDiv";
-import NormalTitle from "../../components/text/NormalTitle";
-import StockGroup from "./component/stockGroup";
+// import { useEffect, useState } from "react";
+// import { useLocation } from "react-router-dom";
+// import ButtonBar from "../../components/button/ButtonBar";
+// import PaddingDiv from "../../components/settingdiv/PaddingDiv";
+// import NormalTitle from "../../components/text/NormalTitle";
+// import StockGroup from "./component/StockGroup";
 
-export default function SelectedStockPage() {
-  const location = useLocation();
+// export default function SelectedStockPage() {
+//   const location = useLocation();
 
-  const { selectedStock } = location.state as {
-    selectedStock: [string, string, number, number, number][];
-  };
+//   const { selectedStock } = location.state as {
+//     selectedStock: [string, string, number, number, number][];
+//   };
 
-  const { stocks } = location.state as {
-    stocks: [string, string, number, number, number][];
-  };
+//   const { stocks } = location.state as {
+//     stocks: [string, string, number, number, number][];
+//   };
 
-  useEffect(() => {
-    console.log(selectedStock);
-  }, [selectedStock]);
+//   useEffect(() => {
+//     console.log(selectedStock);
+//   }, [selectedStock]);
 
-  const [updatedStock, setUpdatedStock] =
-    useState<[string, string, number, number, number][]>(selectedStock);
+//   const [updatedStock, setUpdatedStock] =
+//     useState<[string, string, number, number, number][]>(selectedStock);
 
-  const [nowLimit, setNowLimit] = useState<number>(0);
+//   const [nowLimit, setNowLimit] = useState<number>(0);
 
-  const updateNowLimit = () => {
-    let totalLimit = 0;
-    for (let i = 0; i < selectedStock.length; i++) {
-      if (selectedStock[i][2] != 0) {
-        totalLimit += selectedStock[i][4] * selectedStock[i][2];
-      }
-    }
-    setNowLimit(totalLimit);
-  };
+//   const updateNowLimit = () => {
+//     let totalLimit = 0;
+//     for (let i = 0; i < selectedStock.length; i++) {
+//       if (selectedStock[i][2] != 0) {
+//         totalLimit += selectedStock[i][4] * selectedStock[i][2];
+//       }
+//     }
+//     setNowLimit(totalLimit);
+//   };
 
-  useEffect(() => {
-    updateNowLimit();
-  }, [updatedStock]);
+//   useEffect(() => {
+//     updateNowLimit();
+//   }, [updatedStock]);
 
-  //선택한 주식 리스트 업데이트
-  const updatedUpdatedStock = (index: number, value: number) => {
-    const tempRow: [string, string, number, number, number] = [
-      updatedStock[index][0],
-      updatedStock[index][1],
-      value,
-      updatedStock[index][3],
-      updatedStock[index][4],
-    ];
+//   //선택한 주식 리스트 업데이트
+//   const updatedUpdatedStock = (index: number, value: number) => {
+//     const tempRow: [string, string, number, number, number] = [
+//       updatedStock[index][0],
+//       updatedStock[index][1],
+//       value,
+//       updatedStock[index][3],
+//       updatedStock[index][4],
+//     ];
 
-    const tempArr: [string, string, number, number, number][] = [
-      ...updatedStock.slice(0, index),
-      tempRow,
-      ...updatedStock.slice(index + 1),
-    ];
-    setUpdatedStock(tempArr);
-  };
+//     const tempArr: [string, string, number, number, number][] = [
+//       ...updatedStock.slice(0, index),
+//       tempRow,
+//       ...updatedStock.slice(index + 1),
+//     ];
+//     setUpdatedStock(tempArr);
+//   };
 
-  const handleUpdatedStock = (index: number, value: number) => {
-    updatedUpdatedStock(index, value);
-  };
+//   const handleUpdatedStock = (index: number, value: number) => {
+//     updatedUpdatedStock(index, value);
+//   };
 
-  useEffect(() => {
-    console.log("업데이트된 주식 리스트 ");
-    console.log(updatedStock);
-  }, [updatedStock]);
-  return (
-    <PaddingDiv>
-      <NormalTitle>
-        현재 확보한 총 한도는
-        <span className="font-bold text-blue-700"> {nowLimit}원</span> 입니다.
-        <div className="text-sm	text-gray-400">
-          종목을 클릭하면 주수 조절이 가능합니다.
-        </div>
-      </NormalTitle>
-      <div className="flex flex-col">
-        <div>
-          <StockGroup
-            originalStock={stocks}
-            stockList={updatedStock}
-            handleUpdatedStock={handleUpdatedStock}
-          />
-        </div>
-      </div>
-      <ButtonBar
-        beforetext="이전"
-        nexttext="완료"
-        beforeurl="/stockcheck"
-        beforestate={{ gotStock: selectedStock }}
-        nexturl="/stockcheck"
-        nextstate={{ gotStock: updatedStock }}
-      />
-    </PaddingDiv>
-  );
-}
+//   useEffect(() => {
+//     console.log("업데이트된 주식 리스트 ");
+//     console.log(updatedStock);
+//   }, [updatedStock]);
+//   return (
+//     <PaddingDiv>
+//       <NormalTitle>
+//         현재 확보한 총 한도는
+//         <span className="font-bold text-blue-700"> {nowLimit}원</span> 입니다.
+//         <div className="text-sm	text-gray-400">
+//           종목을 클릭하면 주수 조절이 가능합니다.
+//         </div>
+//       </NormalTitle>
+//       <div className="flex flex-col">
+//         <div>
+//           <StockGroup
+//             originalStock={stocks}
+//             stockList={updatedStock}
+//             handleUpdatedStock={handleUpdatedStock}
+//           />
+//         </div>
+//       </div>
+//       <ButtonBar
+//         beforetext="이전"
+//         nexttext="완료"
+//         beforeurl="/stockcheck"
+//         beforestate={{ gotStock: selectedStock }}
+//         nexturl="/stockcheck"
+//         nextstate={{ gotStock: updatedStock }}
+//       />
+//     </PaddingDiv>
+//   );
+// }

--- a/frontend/src/routes/selectedstock/SelectedStockPage.tsx
+++ b/frontend/src/routes/selectedstock/SelectedStockPage.tsx
@@ -1,24 +1,23 @@
 import { useEffect, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import ButtonBar from "../../components/button/ButtonBar";
 import PaddingDiv from "../../components/settingdiv/PaddingDiv";
 import NormalTitle from "../../components/text/NormalTitle";
-import BackgroundFrame from "../../components/backgroundframe/BackgroundFrame";
+import StockGroup from "./component/stockGroup";
 
 export default function SelectedStockPage() {
-  //const navigate = useNavigate();
   const location = useLocation();
 
   const { selectedStock } = location.state as {
     selectedStock: [string, string, number, number, number][];
   };
 
-  const [updatedStock, setUpdatedStock] =
-    useState<[string, string, number, number, number][]>(selectedStock);
-
   useEffect(() => {
     console.log(selectedStock);
   }, [selectedStock]);
+
+  const [updatedStock, setUpdatedStock] =
+    useState<[string, string, number, number, number][]>(selectedStock);
 
   const [nowLimit, setNowLimit] = useState<number>(() => {
     let totalLimit = 0;
@@ -30,6 +29,42 @@ export default function SelectedStockPage() {
     return totalLimit;
   });
 
+  const [pick, setPick] = useState<
+    [number, string, string, number, number, number][] | undefined
+  >(undefined);
+  const [unPick, setUnPick] = useState<
+    [number, string, string, number, number, number][] | undefined
+  >(undefined);
+
+  const updatePicks = () => {
+    for (let i = 0; i < updatedStock.length; i++) {
+      const now = updatedStock[i];
+      const temp: [number, string, string, number, number, number] = [
+        i,
+        ...now,
+      ];
+
+      if (now[2] !== 0) {
+        setPick((prevPick) => {
+          return prevPick !== undefined ? [...prevPick, temp] : [temp];
+        });
+      } else {
+        setUnPick((prevUnPick) => {
+          return prevUnPick !== undefined ? [...prevUnPick, temp] : [temp];
+        });
+      }
+    }
+  };
+
+  useEffect(() => {
+    updatePicks();
+    console.log("update!");
+  }, []);
+
+  useEffect(() => {
+    console.log("pick is" + pick);
+  }, [pick]);
+
   return (
     <PaddingDiv>
       <NormalTitle>
@@ -40,14 +75,14 @@ export default function SelectedStockPage() {
         </div>
       </NormalTitle>
       <div className="flex flex-col">
-        <NormalTitle>선택한 주식</NormalTitle>
-        <BackgroundFrame color="blue">
-          <div>여기 선택한 주식</div>
-        </BackgroundFrame>
-        <NormalTitle>선택 안 한 주식</NormalTitle>
-        <BackgroundFrame color="blue">
-          <div>여기 선택 안한 주식</div>
-        </BackgroundFrame>
+        <div>
+          <NormalTitle>선택한 주식</NormalTitle>
+          <StockGroup stockList={pick} />
+        </div>
+        <div>
+          <NormalTitle>선택 안 한 주식</NormalTitle>
+          <StockGroup stockList={unPick} />
+        </div>
       </div>
       <ButtonBar
         beforetext="이전"

--- a/frontend/src/routes/selectedstock/SelectedStockPage.tsx
+++ b/frontend/src/routes/selectedstock/SelectedStockPage.tsx
@@ -12,6 +12,10 @@ export default function SelectedStockPage() {
     selectedStock: [string, string, number, number, number][];
   };
 
+  const { stocks } = location.state as {
+    stocks: [string, string, number, number, number][];
+  };
+
   useEffect(() => {
     console.log(selectedStock);
   }, [selectedStock]);
@@ -19,69 +23,64 @@ export default function SelectedStockPage() {
   const [updatedStock, setUpdatedStock] =
     useState<[string, string, number, number, number][]>(selectedStock);
 
-  const [nowLimit, setNowLimit] = useState<number>(() => {
+  const [nowLimit, setNowLimit] = useState<number>(0);
+
+  const updateNowLimit = () => {
     let totalLimit = 0;
     for (let i = 0; i < selectedStock.length; i++) {
       if (selectedStock[i][2] != 0) {
         totalLimit += selectedStock[i][4] * selectedStock[i][2];
       }
     }
-    return totalLimit;
-  });
-
-  const [pick, setPick] = useState<
-    [number, string, string, number, number, number][] | undefined
-  >(undefined);
-  const [unPick, setUnPick] = useState<
-    [number, string, string, number, number, number][] | undefined
-  >(undefined);
-
-  const updatePicks = () => {
-    for (let i = 0; i < updatedStock.length; i++) {
-      const now = updatedStock[i];
-      const temp: [number, string, string, number, number, number] = [
-        i,
-        ...now,
-      ];
-
-      if (now[2] !== 0) {
-        setPick((prevPick) => {
-          return prevPick !== undefined ? [...prevPick, temp] : [temp];
-        });
-      } else {
-        setUnPick((prevUnPick) => {
-          return prevUnPick !== undefined ? [...prevUnPick, temp] : [temp];
-        });
-      }
-    }
+    setNowLimit(totalLimit);
   };
 
   useEffect(() => {
-    updatePicks();
-    console.log("update!");
-  }, []);
+    updateNowLimit();
+  }, [updatedStock]);
+
+  //선택한 주식 리스트 업데이트
+  const updatedUpdatedStock = (index: number, value: number) => {
+    const tempRow: [string, string, number, number, number] = [
+      updatedStock[index][0],
+      updatedStock[index][1],
+      value,
+      updatedStock[index][3],
+      updatedStock[index][4],
+    ];
+
+    const tempArr: [string, string, number, number, number][] = [
+      ...updatedStock.slice(0, index),
+      tempRow,
+      ...updatedStock.slice(index + 1),
+    ];
+    setUpdatedStock(tempArr);
+  };
+
+  const handleUpdatedStock = (index: number, value: number) => {
+    updatedUpdatedStock(index, value);
+  };
 
   useEffect(() => {
-    console.log("pick is" + pick);
-  }, [pick]);
-
+    console.log("업데이트된 주식 리스트 ");
+    console.log(updatedStock);
+  }, [updatedStock]);
   return (
     <PaddingDiv>
       <NormalTitle>
         현재 확보한 총 한도는
         <span className="font-bold text-blue-700"> {nowLimit}원</span> 입니다.
         <div className="text-sm	text-gray-400">
-          종목을 클릭하면 수정 또는 삭제가 가능합니다.
+          종목을 클릭하면 주수 조절이 가능합니다.
         </div>
       </NormalTitle>
       <div className="flex flex-col">
         <div>
-          <NormalTitle>선택한 주식</NormalTitle>
-          <StockGroup stockList={pick} />
-        </div>
-        <div>
-          <NormalTitle>선택 안 한 주식</NormalTitle>
-          <StockGroup stockList={unPick} />
+          <StockGroup
+            originalStock={stocks}
+            stockList={updatedStock}
+            handleUpdatedStock={handleUpdatedStock}
+          />
         </div>
       </div>
       <ButtonBar
@@ -89,8 +88,8 @@ export default function SelectedStockPage() {
         nexttext="완료"
         beforeurl="/stockcheck"
         beforestate={{ gotStock: selectedStock }}
-        nexturl="/priority"
-        nextstate={{ updatedStock: updatedStock }}
+        nexturl="/stockcheck"
+        nextstate={{ gotStock: updatedStock }}
       />
     </PaddingDiv>
   );

--- a/frontend/src/routes/selectedstock/SelectedStockPage.tsx
+++ b/frontend/src/routes/selectedstock/SelectedStockPage.tsx
@@ -1,10 +1,14 @@
 import ButtonBar from "../../components/button/ButtonBar";
 import PaddingDiv from "../../components/settingdiv/PaddingDiv";
+import NormalTitle from "../../components/text/NormalTitle";
 
 export default function SelectedStockPage() {
   return (
     <PaddingDiv>
-      this is selected stock page!
+      <NormalTitle>
+        현재 확보한 총 한도는{" "}
+        <span className="font-bold text-blue-700">1000000원</span> 입니다.
+      </NormalTitle>
       <ButtonBar
         beforetext="이전"
         nexttext="완료"

--- a/frontend/src/routes/selectedstock/component/ChangeStockBar.tsx
+++ b/frontend/src/routes/selectedstock/component/ChangeStockBar.tsx
@@ -1,70 +1,70 @@
-import Select from "react-select";
+// import Select from "react-select";
 
-interface SelectProps {
-  index: number;
-  count: number;
-  selected: number | null;
-  handleSelectedChage: (index: number, value: number) => void;
-}
+// interface SelectProps {
+//   index: number;
+//   count: number;
+//   selected: number | null;
+//   handleSelectedChage: (index: number, value: number) => void;
+// }
 
-const customStyles = {
-  control: (provided: any) => ({
-    ...provided,
-    minHeight: "100%", // control 높이를 부모 div 높이에 맞춤
-    height: "100%", // 고정 높이
-  }),
-  valueContainer: (provided: any) => ({
-    ...provided,
-    height: "100%", // 내부 값 컨테이너 높이를 맞춤
-    padding: "0 8px",
-  }),
-  input: (provided: any) => ({
-    ...provided,
-    margin: "0px",
-  }),
-  indicatorsContainer: (provided: any) => ({
-    ...provided,
-    height: "100%", // 드롭다운 아이콘 컨테이너 높이 맞춤
-  }),
-  menu: (provided: any) => ({
-    ...provided,
-    maxHeight: "150px", // 옵션 목록의 최대 높이 설정
-  }),
-  menuList: (provided: any) => ({
-    ...provided,
-    maxHeight: "70px", // 옵션 목록의 최대 높이 설정
-    overflowY: "auto", // 스크롤 설정
-  }),
-};
+// const customStyles = {
+//   control: (provided: any) => ({
+//     ...provided,
+//     minHeight: "100%", // control 높이를 부모 div 높이에 맞춤
+//     height: "100%", // 고정 높이
+//   }),
+//   valueContainer: (provided: any) => ({
+//     ...provided,
+//     height: "100%", // 내부 값 컨테이너 높이를 맞춤
+//     padding: "0 8px",
+//   }),
+//   input: (provided: any) => ({
+//     ...provided,
+//     margin: "0px",
+//   }),
+//   indicatorsContainer: (provided: any) => ({
+//     ...provided,
+//     height: "100%", // 드롭다운 아이콘 컨테이너 높이 맞춤
+//   }),
+//   menu: (provided: any) => ({
+//     ...provided,
+//     maxHeight: "150px", // 옵션 목록의 최대 높이 설정
+//   }),
+//   menuList: (provided: any) => ({
+//     ...provided,
+//     maxHeight: "70px", // 옵션 목록의 최대 높이 설정
+//     overflowY: "auto", // 스크롤 설정
+//   }),
+// };
 
-export default function ChangeStockBar({
-  index,
-  count,
-  selected,
-  handleSelectedChage,
-}: SelectProps) {
-  const range: { value: number; label: number }[] = [];
-  for (let i = 0; i <= count; i++) {
-    range.push({ value: i, label: i });
-  }
+// export default function ChangeStockBar({
+//   index,
+//   count,
+//   selected,
+//   handleSelectedChage,
+// }: SelectProps) {
+//   const range: { value: number; label: number }[] = [];
+//   for (let i = 0; i <= count; i++) {
+//     range.push({ value: i, label: i });
+//   }
 
-  const onChangeSelected = (selected: any) => {
-    if (
-      selected &&
-      selected.value !== null &&
-      selected &&
-      selected.value !== undefined
-    ) {
-      handleSelectedChage(index, selected.value);
-    }
-  };
+//   const onChangeSelected = (selected: any) => {
+//     if (
+//       selected &&
+//       selected.value !== null &&
+//       selected &&
+//       selected.value !== undefined
+//     ) {
+//       handleSelectedChage(index, selected.value);
+//     }
+//   };
 
-  return (
-    <Select
-      options={range}
-      defaultValue={selected !== null ? range[selected] : range[0]}
-      onChange={onChangeSelected}
-      styles={customStyles}
-    />
-  );
-}
+//   return (
+//     <Select
+//       options={range}
+//       defaultValue={selected !== null ? range[selected] : range[0]}
+//       onChange={onChangeSelected}
+//       styles={customStyles}
+//     />
+//   );
+// }

--- a/frontend/src/routes/selectedstock/component/ChangeStockBar.tsx
+++ b/frontend/src/routes/selectedstock/component/ChangeStockBar.tsx
@@ -1,9 +1,10 @@
 import Select from "react-select";
 
 interface SelectProps {
+  index: number;
   count: number;
-  selectedCount: number;
-  handleSelectedChage: (selected: number) => void;
+  selected: number | null;
+  handleSelectedChage: (index: number, value: number) => void;
 }
 
 const customStyles = {
@@ -36,9 +37,10 @@ const customStyles = {
   }),
 };
 
-export default function SelectStockBar({
+export default function ChangeStockBar({
+  index,
   count,
-  selectedCount,
+  selected,
   handleSelectedChage,
 }: SelectProps) {
   const range: { value: number; label: number }[] = [];
@@ -46,23 +48,21 @@ export default function SelectStockBar({
     range.push({ value: i, label: i });
   }
 
-  console.log("선택한 주식량" + selectedCount);
   const onChangeSelected = (selected: any) => {
-    console.log("onChangeSelected");
     if (
       selected &&
       selected.value !== null &&
       selected &&
       selected.value !== undefined
     ) {
-      handleSelectedChage(selected.value);
+      handleSelectedChage(index, selected.value);
     }
   };
 
   return (
     <Select
       options={range}
-      value={range[selectedCount]}
+      defaultValue={selected !== null ? range[selected] : range[0]}
       onChange={onChangeSelected}
       styles={customStyles}
     />

--- a/frontend/src/routes/selectedstock/component/StockGroup.tsx
+++ b/frontend/src/routes/selectedstock/component/StockGroup.tsx
@@ -15,7 +15,7 @@ export default function StockGroup({
   handleUpdatedStock,
 }: StockProps) {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
-  const [clickedValue, setClickedValue] = useState<number | null>(null);
+  const [clickedValue, setClickedValue] = useState<number>(0);
   const [maxValue, setMaxValue] = useState<number>(0);
   const [nowIndex, setNowIndex] = useState<number>(0);
   const openModal = () => setIsModalOpen(true);
@@ -33,7 +33,7 @@ export default function StockGroup({
   };
 
   const handleCloseModal = () => {
-    setClickedValue(null);
+    setClickedValue(0);
     setMaxValue(0);
     setNowIndex(0);
     closeModal();

--- a/frontend/src/routes/selectedstock/component/StockGroup.tsx
+++ b/frontend/src/routes/selectedstock/component/StockGroup.tsx
@@ -1,0 +1,28 @@
+import BackgroundFrame from "../../../components/backgroundframe/BackgroundFrame";
+
+interface StockProps {
+  stockList?: [number, string, string, number, number, number][];
+}
+
+export default function StockGroup({ stockList }: StockProps) {
+  return (
+    <BackgroundFrame color="blue">
+      <div className="text-sm">
+        종목명 | 선택한 주수 | 전일 종가 | 등급 | 가능 한도
+        <hr />
+        <div>
+          {stockList ? (
+            stockList.map((item, index) => (
+              // key 속성에 고유한 값을 사용하여 각 요소에 고유 식별자를 할당합니다.
+              <div key={index}>
+                {item[1]} | {item[3]} | {item[4]} | {item[2]} |{item[5]}
+              </div>
+            ))
+          ) : (
+            <div>No data available</div> // data가 undefined일 때 보여줄 대체 내용
+          )}
+        </div>
+      </div>
+    </BackgroundFrame>
+  );
+}

--- a/frontend/src/routes/selectedstock/component/StockGroup.tsx
+++ b/frontend/src/routes/selectedstock/component/StockGroup.tsx
@@ -1,28 +1,168 @@
+import { useState } from "react";
 import BackgroundFrame from "../../../components/backgroundframe/BackgroundFrame";
+import BoldTitle from "../../../components/text/BoldTitle";
+import StockEditModal from "../../stockcheck/component/StockEditModal";
 
 interface StockProps {
-  stockList?: [number, string, string, number, number, number][];
+  originalStock: [string, string, number, number, number][];
+  stockList: [string, string, number, number, number][];
+  handleUpdatedStock: (index: number, value: number) => void;
 }
 
-export default function StockGroup({ stockList }: StockProps) {
+export default function StockGroup({
+  originalStock,
+  stockList,
+  handleUpdatedStock,
+}: StockProps) {
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [clickedValue, setClickedValue] = useState<number | null>(null);
+  const [maxValue, setMaxValue] = useState<number>(0);
+  const [nowIndex, setNowIndex] = useState<number>(0);
+  const openModal = () => setIsModalOpen(true);
+  const closeModal = () => setIsModalOpen(false);
+
+  const updateStockList = (index: number, value: number) => {
+    handleUpdatedStock(index, value);
+  };
+
+  const handleOpenModal = (index: number, value: number, max: number) => {
+    setClickedValue(value);
+    setMaxValue(max);
+    setNowIndex(index);
+    openModal();
+  };
+
+  const handleCloseModal = () => {
+    setClickedValue(null);
+    setMaxValue(0);
+    setNowIndex(0);
+    closeModal();
+  };
+
   return (
-    <BackgroundFrame color="blue">
-      <div className="text-sm">
-        종목명 | 선택한 주수 | 전일 종가 | 등급 | 가능 한도
-        <hr />
-        <div>
-          {stockList ? (
-            stockList.map((item, index) => (
-              // key 속성에 고유한 값을 사용하여 각 요소에 고유 식별자를 할당합니다.
-              <div key={index}>
-                {item[1]} | {item[3]} | {item[4]} | {item[2]} |{item[5]}
-              </div>
-            ))
-          ) : (
-            <div>No data available</div> // data가 undefined일 때 보여줄 대체 내용
-          )}
-        </div>
+    <div>
+      <div>
+        <BoldTitle>선택한 주식</BoldTitle>
+        <BackgroundFrame color="blue">
+          <div className="text-sm">
+            <table
+              style={{
+                width: "100%",
+                borderCollapse: "collapse",
+                textAlign: "center",
+              }}
+            >
+              <thead>
+                <tr>
+                  <th>종목명</th>
+                  <th>선택한 주수</th>
+                  <th>전일 종가</th>
+                  <th>등급</th>
+                  <th>가능 한도</th>
+                </tr>
+              </thead>
+              <tbody>
+                {stockList ? (
+                  stockList.map((item, index) =>
+                    item[2] != 0 ? (
+                      <tr
+                        key={index}
+                        onClick={() =>
+                          handleOpenModal(
+                            index,
+                            item[2],
+                            originalStock[index][2]
+                          )
+                        }
+                        style={{
+                          cursor: "pointer",
+                        }}
+                      >
+                        <td>{item[0]}</td>
+                        <td>{item[2]}</td>
+                        <td>{item[3]}</td>
+                        <td>{item[1]}</td>
+                        <td>{item[4]}</td>
+                        <div></div>
+                      </tr>
+                    ) : (
+                      <div></div>
+                    )
+                  )
+                ) : (
+                  <div>아무것도 없어요!</div>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </BackgroundFrame>
       </div>
-    </BackgroundFrame>
+      <div>
+        <BoldTitle>선택 안 한 주식</BoldTitle>
+        <BackgroundFrame color="blue">
+          <div className="text-sm">
+            <table
+              style={{
+                width: "100%",
+                borderCollapse: "collapse",
+                textAlign: "center",
+              }}
+            >
+              <thead>
+                <tr>
+                  <th>종목명</th>
+                  <th>선택한 주수</th>
+                  <th>전일 종가</th>
+                  <th>등급</th>
+                  <th>가능 한도</th>
+                </tr>
+              </thead>
+              <tbody>
+                {stockList ? (
+                  stockList.map((item, index) =>
+                    item[2] == 0 ? (
+                      <tr
+                        key={index}
+                        //onClick={() => updateStockList(index, item[2])}
+                        onClick={() =>
+                          handleOpenModal(
+                            index,
+                            item[2],
+                            originalStock[index][2]
+                          )
+                        }
+                        style={{
+                          cursor: "pointer",
+                        }}
+                      >
+                        <td>{item[0]}</td>
+                        <td>{item[2]}</td>
+                        <td>{item[3]}</td>
+                        <td>{item[1]}</td>
+                        <td>{item[4]}</td>
+                      </tr>
+                    ) : (
+                      <div></div>
+                    )
+                  )
+                ) : (
+                  <div>아무것도 없어요!</div>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </BackgroundFrame>
+      </div>
+      {isModalOpen && (
+        <StockEditModal
+          index={nowIndex}
+          value={clickedValue}
+          max={maxValue}
+          isModalOpen={isModalOpen}
+          onCloseModal={handleCloseModal}
+          updateStockList={updateStockList}
+        />
+      )}
+    </div>
   );
 }

--- a/frontend/src/routes/selectedstock/component/StockGroup.tsx
+++ b/frontend/src/routes/selectedstock/component/StockGroup.tsx
@@ -1,168 +1,168 @@
-import { useState } from "react";
-import BackgroundFrame from "../../../components/backgroundframe/BackgroundFrame";
-import BoldTitle from "../../../components/text/BoldTitle";
-import StockEditModal from "../../stockcheck/component/StockEditModal";
+// import { useState } from "react";
+// import BackgroundFrame from "../../../components/backgroundframe/BackgroundFrame";
+// import BoldTitle from "../../../components/text/BoldTitle";
+// import StockEditModal from "../../stockcheck/component/StockEditModal";
 
-interface StockProps {
-  originalStock: [string, string, number, number, number][];
-  stockList: [string, string, number, number, number][];
-  handleUpdatedStock: (index: number, value: number) => void;
-}
+// interface StockProps {
+//   originalStock: [string, string, number, number, number][];
+//   stockList: [string, string, number, number, number][];
+//   handleUpdatedStock: (index: number, value: number) => void;
+// }
 
-export default function StockGroup({
-  originalStock,
-  stockList,
-  handleUpdatedStock,
-}: StockProps) {
-  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
-  const [clickedValue, setClickedValue] = useState<number>(0);
-  const [maxValue, setMaxValue] = useState<number>(0);
-  const [nowIndex, setNowIndex] = useState<number>(0);
-  const openModal = () => setIsModalOpen(true);
-  const closeModal = () => setIsModalOpen(false);
+// export default function StockGroup({
+//   originalStock,
+//   stockList,
+//   handleUpdatedStock,
+// }: StockProps) {
+//   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+//   const [clickedValue, setClickedValue] = useState<number>(0);
+//   const [maxValue, setMaxValue] = useState<number>(0);
+//   const [nowIndex, setNowIndex] = useState<number>(0);
+//   const openModal = () => setIsModalOpen(true);
+//   const closeModal = () => setIsModalOpen(false);
 
-  const updateStockList = (index: number, value: number) => {
-    handleUpdatedStock(index, value);
-  };
+//   const updateStockList = (index: number, value: number) => {
+//     handleUpdatedStock(index, value);
+//   };
 
-  const handleOpenModal = (index: number, value: number, max: number) => {
-    setClickedValue(value);
-    setMaxValue(max);
-    setNowIndex(index);
-    openModal();
-  };
+//   const handleOpenModal = (index: number, value: number, max: number) => {
+//     setClickedValue(value);
+//     setMaxValue(max);
+//     setNowIndex(index);
+//     openModal();
+//   };
 
-  const handleCloseModal = () => {
-    setClickedValue(0);
-    setMaxValue(0);
-    setNowIndex(0);
-    closeModal();
-  };
+//   const handleCloseModal = () => {
+//     setClickedValue(0);
+//     setMaxValue(0);
+//     setNowIndex(0);
+//     closeModal();
+//   };
 
-  return (
-    <div>
-      <div>
-        <BoldTitle>선택한 주식</BoldTitle>
-        <BackgroundFrame color="blue">
-          <div className="text-sm">
-            <table
-              style={{
-                width: "100%",
-                borderCollapse: "collapse",
-                textAlign: "center",
-              }}
-            >
-              <thead>
-                <tr>
-                  <th>종목명</th>
-                  <th>선택한 주수</th>
-                  <th>전일 종가</th>
-                  <th>등급</th>
-                  <th>가능 한도</th>
-                </tr>
-              </thead>
-              <tbody>
-                {stockList ? (
-                  stockList.map((item, index) =>
-                    item[2] != 0 ? (
-                      <tr
-                        key={index}
-                        onClick={() =>
-                          handleOpenModal(
-                            index,
-                            item[2],
-                            originalStock[index][2]
-                          )
-                        }
-                        style={{
-                          cursor: "pointer",
-                        }}
-                      >
-                        <td>{item[0]}</td>
-                        <td>{item[2]}</td>
-                        <td>{item[3]}</td>
-                        <td>{item[1]}</td>
-                        <td>{item[4]}</td>
-                        <div></div>
-                      </tr>
-                    ) : (
-                      <div></div>
-                    )
-                  )
-                ) : (
-                  <div>아무것도 없어요!</div>
-                )}
-              </tbody>
-            </table>
-          </div>
-        </BackgroundFrame>
-      </div>
-      <div>
-        <BoldTitle>선택 안 한 주식</BoldTitle>
-        <BackgroundFrame color="blue">
-          <div className="text-sm">
-            <table
-              style={{
-                width: "100%",
-                borderCollapse: "collapse",
-                textAlign: "center",
-              }}
-            >
-              <thead>
-                <tr>
-                  <th>종목명</th>
-                  <th>선택한 주수</th>
-                  <th>전일 종가</th>
-                  <th>등급</th>
-                  <th>가능 한도</th>
-                </tr>
-              </thead>
-              <tbody>
-                {stockList ? (
-                  stockList.map((item, index) =>
-                    item[2] == 0 ? (
-                      <tr
-                        key={index}
-                        //onClick={() => updateStockList(index, item[2])}
-                        onClick={() =>
-                          handleOpenModal(
-                            index,
-                            item[2],
-                            originalStock[index][2]
-                          )
-                        }
-                        style={{
-                          cursor: "pointer",
-                        }}
-                      >
-                        <td>{item[0]}</td>
-                        <td>{item[2]}</td>
-                        <td>{item[3]}</td>
-                        <td>{item[1]}</td>
-                        <td>{item[4]}</td>
-                      </tr>
-                    ) : (
-                      <div></div>
-                    )
-                  )
-                ) : (
-                  <div>아무것도 없어요!</div>
-                )}
-              </tbody>
-            </table>
-          </div>
-        </BackgroundFrame>
-      </div>
-      {isModalOpen && (
-        <StockEditModal
-          index={nowIndex}
-          value={clickedValue}
-          max={maxValue}
-          isModalOpen={isModalOpen}
-          onCloseModal={handleCloseModal}
-          updateStockList={updateStockList}
-        />
-      )}
-    </div>
-  );
-}
+//   return (
+//     <div>
+//       <div>
+//         <BoldTitle>선택한 주식</BoldTitle>
+//         <BackgroundFrame color="blue">
+//           <div className="text-sm">
+//             <table
+//               style={{
+//                 width: "100%",
+//                 borderCollapse: "collapse",
+//                 textAlign: "center",
+//               }}
+//             >
+//               <thead>
+//                 <tr>
+//                   <th>종목명</th>
+//                   <th>선택한 주수</th>
+//                   <th>전일 종가</th>
+//                   <th>등급</th>
+//                   <th>가능 한도</th>
+//                 </tr>
+//               </thead>
+//               <tbody>
+//                 {stockList ? (
+//                   stockList.map((item, index) =>
+//                     item[2] != 0 ? (
+//                       <tr
+//                         key={index}
+//                         onClick={() =>
+//                           handleOpenModal(
+//                             index,
+//                             item[2],
+//                             originalStock[index][2]
+//                           )
+//                         }
+//                         style={{
+//                           cursor: "pointer",
+//                         }}
+//                       >
+//                         <td>{item[0]}</td>
+//                         <td>{item[2]}</td>
+//                         <td>{item[3]}</td>
+//                         <td>{item[1]}</td>
+//                         <td>{item[4]}</td>
+//                         <div></div>
+//                       </tr>
+//                     ) : (
+//                       <div></div>
+//                     )
+//                   )
+//                 ) : (
+//                   <div>아무것도 없어요!</div>
+//                 )}
+//               </tbody>
+//             </table>
+//           </div>
+//         </BackgroundFrame>
+//       </div>
+//       <div>
+//         <BoldTitle>선택 안 한 주식</BoldTitle>
+//         <BackgroundFrame color="blue">
+//           <div className="text-sm">
+//             <table
+//               style={{
+//                 width: "100%",
+//                 borderCollapse: "collapse",
+//                 textAlign: "center",
+//               }}
+//             >
+//               <thead>
+//                 <tr>
+//                   <th>종목명</th>
+//                   <th>남은 주수</th>
+//                   <th>전일 종가</th>
+//                   <th>등급</th>
+//                   <th>가능 한도</th>
+//                 </tr>
+//               </thead>
+//               <tbody>
+//                 {stockList ? (
+//                   stockList.map((item, index) =>
+//                     item[2] !== originalStock[index][2] ? (
+//                       <tr
+//                         key={index}
+//                         //onClick={() => updateStockList(index, item[2])}
+//                         // onClick={() =>
+//                         //   handleOpenModal(
+//                         //     index,
+//                         //     0,
+//                         //     originalStock[index][2] - item[2]
+//                         //   )
+//                         // }
+//                         style={{
+//                           cursor: "pointer",
+//                         }}
+//                       >
+//                         <td>{item[0]}</td>
+//                         <td>{originalStock[index][2] - item[2]}</td>
+//                         <td>{item[3]}</td>
+//                         <td>{item[1]}</td>
+//                         <td>{item[4]}</td>
+//                       </tr>
+//                     ) : (
+//                       <div></div>
+//                     )
+//                   )
+//                 ) : (
+//                   <div>아무것도 없어요!</div>
+//                 )}
+//               </tbody>
+//             </table>
+//           </div>
+//         </BackgroundFrame>
+//       </div>
+//       {isModalOpen && (
+//         <StockEditModal
+//           index={nowIndex}
+//           value={clickedValue}
+//           max={maxValue}
+//           isModalOpen={isModalOpen}
+//           onCloseModal={handleCloseModal}
+//           updateStockList={updateStockList}
+//         />
+//       )}
+//     </div>
+//   );
+// }

--- a/frontend/src/routes/settinglimit/SettingLimitPage.tsx
+++ b/frontend/src/routes/settinglimit/SettingLimitPage.tsx
@@ -1,0 +1,5 @@
+import PaddingDiv from "../../components/settingdiv/PaddingDiv";
+
+export default function SettingLimitPage() {
+  return <PaddingDiv>한도설정 페이지입니다.</PaddingDiv>;
+}

--- a/frontend/src/routes/stock/ShowSelectedPage.tsx
+++ b/frontend/src/routes/stock/ShowSelectedPage.tsx
@@ -1,0 +1,113 @@
+import { useState, useEffect } from "react";
+import PaddingDiv from "../../components/settingdiv/PaddingDiv";
+import NormalTitle from "../../components/text/NormalTitle";
+import StockFrame from "./component/StockFrame";
+import SelectedStockButtonbar from "./component/SelectedStockButtonbar";
+
+interface StockProps {
+  selectedStock: [
+    string,
+    string,
+    string,
+    string,
+    number,
+    number,
+    number,
+    number,
+    string
+  ][];
+  handleSelectedStock: (index: number, amount: number) => void;
+  handlePage: (p: number) => void;
+}
+
+export default function ShowSelectedPage({
+  selectedStock,
+  handleSelectedStock,
+  handlePage,
+}: StockProps) {
+  const [temp, setTemp] = useState<
+    [string, string, string, string, number, number, number, number, string][]
+  >([...selectedStock]);
+
+  const handleTemp = (index: number, amount: number) => {
+    const newRow: [
+      string,
+      string,
+      string,
+      string,
+      number,
+      number,
+      number,
+      number,
+      string
+    ] = [
+      temp[index][0],
+      temp[index][1],
+      temp[index][2],
+      temp[index][3],
+      temp[index][4],
+      amount,
+      temp[index][6],
+      temp[index][7],
+      temp[index][8],
+    ];
+
+    const t: [
+      string,
+      string,
+      string,
+      string,
+      number,
+      number,
+      number,
+      number,
+      string
+    ][] = [...temp.slice(0, index), newRow, ...temp.slice(index + 1)];
+    setTemp(t);
+  };
+
+  useEffect(() => {
+    console.log("temp is " + temp);
+  }, [temp]);
+
+  const clickFinishButton = () => {
+    for (let i = 0; i < temp.length; i++) {
+      console.log("click finish button: " + i + "is " + temp[i][5]);
+      handleSelectedStock(i, temp[i][5]);
+    }
+  };
+
+  const [limit, setLimit] = useState<number>(0);
+  const calculateLimit = () => {
+    let totalLimit = 0;
+    for (let i = 0; i < temp.length; i++) {
+      totalLimit += temp[i][5] * temp[i][7];
+    }
+    return totalLimit;
+  };
+  useEffect(() => {
+    setLimit(calculateLimit);
+  }, [temp]);
+
+  return (
+    <PaddingDiv>
+      <NormalTitle>
+        현재 확보한 총 한도는
+        <span className="font-bold text-blue-700"> {limit}원</span> 입니다.
+        <div className="text-sm	text-gray-400">
+          각 종목을 클릭하면 선택할 주수 조절이 가능합니다.
+        </div>
+      </NormalTitle>
+
+      <div className="flex flex-col">
+        <div>
+          <StockFrame stocks={temp} handleTemp={handleTemp} />
+        </div>
+      </div>
+      <SelectedStockButtonbar
+        handlePage={handlePage}
+        clickFinishButton={clickFinishButton}
+      />
+    </PaddingDiv>
+  );
+}

--- a/frontend/src/routes/stock/StockPage.tsx
+++ b/frontend/src/routes/stock/StockPage.tsx
@@ -7,6 +7,7 @@ import LevelInfoModal from "./component/LevelInfoModel";
 import OwnStockList from "./component/OwnStockList";
 import MoveButton from "../../components/button/MoveButton";
 import ButtonBar from "../../components/button/ButtonBar";
+import { useLocation } from "react-router-dom";
 //import { useNavigate } from "react-router-dom";
 
 export default function StockPage() {
@@ -37,7 +38,8 @@ export default function StockPage() {
 
   //0이면 증권조회 컴포넌트 출력, 1이면 선택한 주식 컴포넌트 출력
   const [page, setPage] = useState<number>(0);
-  //선택한 주식 목록
+
+  //선택한 주식 목록: length = 9
   //회사코드, 회사명, 종목명, 등급, 전일종가, 선택한 주수, 전체 주수, 한도, 계좌번호
   const [selectedStock, setSelectedStock] = useState<
     [string, string, string, string, number, number, number, number, string][]
@@ -220,6 +222,29 @@ export default function StockPage() {
   useEffect(() => {
     setLimit(calculateLimit);
   }, [selectedStock]);
+
+  //다음 페이지에서 주식을 다시 받아옴
+  const location = useLocation();
+
+  const { priorityToStock } = location.state as {
+    priorityToStock: [
+      string,
+      string,
+      string,
+      string,
+      number,
+      number,
+      number,
+      number,
+      string
+    ][];
+  };
+
+  useEffect(() => {
+    if (priorityToStock) {
+      setSelectedStock(priorityToStock);
+    }
+  }, [location.state]);
 
   return (
     <div>

--- a/frontend/src/routes/stock/StockPage.tsx
+++ b/frontend/src/routes/stock/StockPage.tsx
@@ -1,0 +1,283 @@
+import { useEffect, useMemo, useState } from "react";
+import PaddingDiv from "../../components/settingdiv/PaddingDiv";
+import ShowSelectedPage from "./ShowSelectedPage";
+import BoldTitle from "../../components/text/BoldTitle";
+import QuestionButton from "../../components/button/QuestionButton";
+import LevelInfoModal from "./component/LevelInfoModel";
+import OwnStockList from "./component/OwnStockList";
+import MoveButton from "../../components/button/MoveButton";
+import ButtonBar from "../../components/button/ButtonBar";
+//import { useNavigate } from "react-router-dom";
+
+export default function StockPage() {
+  //const navigate = useNavigate();
+  //TODO: 보유주 api로 가져오기
+  //회사코드, 회사명, 종목명, 등급, 전일종가, 주수, 한도, 계좌번호
+  const ownStock: [
+    string,
+    string,
+    string,
+    string,
+    number,
+    number,
+    number,
+    string
+  ][] = useMemo(
+    () => [
+      ["01", "신한투자증권", "삼성전자", "A", 70000, 50, 55000, "1111-1111"],
+      ["01", "신한투자증권", "하이닉스", "A", 50000, 20, 35000, "1111-1111"],
+      ["01", "신한투자증권", "하이닉스", "A", 50000, 30, 35000, "2222-2222"],
+      ["02", "NH투자증권", "삼성전자", "A", 70000, 30, 55000, "3333-3333"],
+    ],
+    []
+  );
+
+  //모달창 관리
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
+  //0이면 증권조회 컴포넌트 출력, 1이면 선택한 주식 컴포넌트 출력
+  const [page, setPage] = useState<number>(0);
+  //선택한 주식 목록
+  //회사코드, 회사명, 종목명, 등급, 전일종가, 선택한 주수, 전체 주수, 한도, 계좌번호
+  const [selectedStock, setSelectedStock] = useState<
+    [string, string, string, string, number, number, number, number, string][]
+  >([]);
+  const [limit, setLimit] = useState<number>(0);
+
+  useEffect(() => {
+    const temp: [
+      string,
+      string,
+      string,
+      string,
+      number,
+      number,
+      number,
+      number,
+      string
+    ][] = ownStock.map((row) => {
+      const newRow: [
+        string,
+        string,
+        string,
+        string,
+        number,
+        number,
+        number,
+        number,
+        string
+      ] = [row[0], row[1], row[2], row[3], row[4], 0, row[5], row[6], row[7]];
+      return newRow;
+    });
+    setSelectedStock(temp);
+  }, [ownStock]);
+
+  const [category, setCategory] = useState<{
+    [key: string]: [
+      number,
+      string,
+      string,
+      string,
+      string,
+      number,
+      number,
+      number,
+      number,
+      string
+    ][];
+  }>({});
+
+  const handleCategory = (
+    arr: [
+      string,
+      string,
+      string,
+      string,
+      number,
+      number,
+      number,
+      number,
+      string
+    ][]
+  ) => {
+    const grouped: {
+      [key: string]: [
+        number,
+        string,
+        string,
+        string,
+        string,
+        number,
+        number,
+        number,
+        number,
+        string
+      ][];
+    } = {};
+
+    arr.forEach((stock, index) => {
+      const key = stock[1];
+      const newStock: [
+        number,
+        string,
+        string,
+        string,
+        string,
+        number,
+        number,
+        number,
+        number,
+        string
+      ] = [index, ...stock];
+
+      //이미 해당 증권사 그룹이 생성돼있다면,
+      if (grouped[key]) {
+        grouped[key].push(newStock);
+      } else {
+        grouped[key] = [newStock];
+      }
+    });
+
+    return grouped;
+  };
+  useEffect(() => {
+    setCategory(handleCategory(selectedStock));
+  }, [selectedStock]);
+
+  const handleSelectedStock = (index: number, amount: number) => {
+    // 상태를 업데이트할 때 최신 상태를 참조하여 업데이트
+    setSelectedStock((prevSelectedStock) => {
+      // 현재 상태의 origin을 기반으로 새로운 행 생성
+      const newRow: [
+        string,
+        string,
+        string,
+        string,
+        number,
+        number,
+        number,
+        number,
+        string
+      ] = [
+        prevSelectedStock[index][0],
+        prevSelectedStock[index][1],
+        prevSelectedStock[index][2],
+        prevSelectedStock[index][3],
+        prevSelectedStock[index][4],
+        amount,
+        prevSelectedStock[index][6],
+        prevSelectedStock[index][7],
+        prevSelectedStock[index][8],
+      ];
+
+      // 새로운 상태 배열 생성
+      const temp: [
+        string,
+        string,
+        string,
+        string,
+        number,
+        number,
+        number,
+        number,
+        string
+      ][] = [
+        ...prevSelectedStock.slice(0, index),
+        newRow,
+        ...prevSelectedStock.slice(index + 1),
+      ];
+
+      // 업데이트된 상태를 반환
+      return temp;
+    });
+  };
+
+  useEffect(() => {
+    console.log("바뀜!");
+    console.log(selectedStock);
+  }, [selectedStock]);
+
+  const openModal = () => setIsModalOpen(true);
+  const closeModal = () => setIsModalOpen(false);
+  const calculateLimit = () => {
+    let totalLimit = 0;
+    for (let i = 0; i < selectedStock.length; i++) {
+      totalLimit += selectedStock[i][5] * selectedStock[i][7];
+    }
+    return totalLimit;
+  };
+
+  const handlePage = (p: number) => {
+    setPage(p);
+  };
+
+  // const autoSelect = () => {
+  //   //한도에 맞춰 주식 선택
+  //   //모달창에 입력받고, 선택한 주식 보여주는 페이지로
+  //   handlePage(1);
+  // };
+
+  useEffect(() => {
+    setLimit(calculateLimit);
+  }, [selectedStock]);
+
+  return (
+    <div>
+      {page == 0 ? (
+        <PaddingDiv>
+          <div className="flex justify-between">
+            <BoldTitle>담보로 잡을 주식을 선택해주세요.</BoldTitle>
+            <div>
+              <div onClick={openModal}>
+                <QuestionButton />
+              </div>
+              {isModalOpen && (
+                <LevelInfoModal
+                  isModalOpen={isModalOpen}
+                  handleCloseModal={closeModal}
+                />
+              )}
+            </div>
+          </div>
+
+          <OwnStockList
+            stocks={category}
+            handleSelectedStock={handleSelectedStock}
+          />
+
+          <div>
+            <div className="mb-5">
+              <div className="flex justify-between mb-5">
+                <BoldTitle>
+                  현재 확보한 최대 한도: <br />
+                  {limit} 원
+                </BoldTitle>
+
+                <MoveButton onClick={() => handlePage(1)}>
+                  선택한 주식 보기
+                </MoveButton>
+              </div>
+              {/*TODO: 이거 클릭 시에 한도 모달 띄우고 선택한 주식 페이지로*/}
+              {/* <div onClick={autoSelect} className="text-sm	text-blue-700">
+                원하는 한도에 맞게 주식을 자동으로 선택해주세요.
+              </div> */}
+            </div>
+            <ButtonBar
+              beforetext="이전"
+              nexttext="다음"
+              beforeurl="/serviceagree"
+              nexturl="/priority"
+              nextstate={{ selectedStock: selectedStock }}
+            ></ButtonBar>
+          </div>
+        </PaddingDiv>
+      ) : (
+        <ShowSelectedPage
+          selectedStock={selectedStock}
+          handleSelectedStock={handleSelectedStock}
+          handlePage={handlePage}
+        ></ShowSelectedPage>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/routes/stock/component/LevelInfoModel.tsx
+++ b/frontend/src/routes/stock/component/LevelInfoModel.tsx
@@ -1,0 +1,25 @@
+import XButton from "../../../components/button/XButton";
+import BasicModal from "../../../components/modal/BasicModal";
+
+interface ModalProps {
+  isModalOpen: boolean;
+  handleCloseModal: () => void;
+}
+
+export default function LevelInfoModal({
+  isModalOpen,
+  handleCloseModal,
+}: ModalProps) {
+  return (
+    <BasicModal isOpen={isModalOpen} onRequestClose={handleCloseModal}>
+      <div className="flex flex-row-reverse">
+        <span onClick={handleCloseModal}>
+          <XButton />
+        </span>
+      </div>
+      <h1>주식 등급 안내</h1>
+      <p>AAA등급: 가장 안정성이 높은 종목</p>
+      <p>AA~A등급: 안정성이 높은 종목</p>
+    </BasicModal>
+  );
+}

--- a/frontend/src/routes/stock/component/OwnStockList.tsx
+++ b/frontend/src/routes/stock/component/OwnStockList.tsx
@@ -1,0 +1,90 @@
+import Slider from "react-slick";
+import styled from "styled-components";
+import NormalTitle from "../../../components/text/NormalTitle";
+import SCard from "./SCard";
+
+interface StockProps {
+  stocks: {
+    [key: string]: [
+      number,
+      string,
+      string,
+      string,
+      string,
+      number,
+      number,
+      number,
+      number,
+      string
+    ][];
+  };
+  handleSelectedStock: (index: number, amount: number) => void;
+}
+
+const Wrapper = styled.div`
+  position: relative;
+  margin-left: -5%;
+  margin-right: -5%;
+
+  .slick-slide {
+    transition: transform 0.3s ease;
+  }
+`;
+
+export default function OwnStockList({
+  stocks,
+  handleSelectedStock,
+}: StockProps) {
+  const settings = {
+    infinite: false,
+    centerMode: true,
+    centerPadding: "25px",
+    slidesToShow: 1,
+    speed: 500,
+    focusOnSelect: true,
+    dots: true,
+    arrows: false,
+    draggable: true, // 드래그 가능 설정
+    swipe: true, // 터치 제스처 스와이프 설정
+    touchThreshold: 10, // 터치 감도 조정
+  };
+
+  return (
+    <div className="flex flex-col gap-10">
+      <div>
+        {Object.entries(stocks).map(([key, values]) => (
+          <div>
+            <NormalTitle>{key}</NormalTitle>
+
+            <Wrapper>
+              <Slider {...settings}>
+                {values.map((stock) => (
+                  <SCard
+                    index={stock[0]}
+                    stockInfo={stock}
+                    handleSelectedStock={handleSelectedStock}
+                  />
+                ))}
+              </Slider>
+            </Wrapper>
+          </div>
+        ))}
+      </div>
+
+      {/* <div>
+        <NormalTitle>신한투자증권</NormalTitle>
+        <Wrapper>
+          <Slider {...settings}>
+            {stocks.map((stock, index) => (
+              <SCard
+                index={index}
+                stockInfo={stock}
+                handleSelectedStock={handleSelectedStock}
+              />
+            ))}
+          </Slider>
+        </Wrapper>
+      </div> */}
+    </div>
+  );
+}

--- a/frontend/src/routes/stock/component/RangeSelectBar.tsx
+++ b/frontend/src/routes/stock/component/RangeSelectBar.tsx
@@ -1,0 +1,69 @@
+import Select from "react-select";
+
+interface SelectProps {
+  index: number;
+  count: number;
+  selected: number;
+  handleTempSelected: (index: number, value: number) => void;
+}
+
+const customStyles = {
+  control: (provided: any) => ({
+    ...provided,
+    minHeight: "100%", // control 높이를 부모 div 높이에 맞춤
+    height: "100%", // 고정 높이
+  }),
+  valueContainer: (provided: any) => ({
+    ...provided,
+    height: "100%", // 내부 값 컨테이너 높이를 맞춤
+    padding: "0 8px",
+  }),
+  input: (provided: any) => ({
+    ...provided,
+    margin: "0px",
+  }),
+  indicatorsContainer: (provided: any) => ({
+    ...provided,
+    height: "100%", // 드롭다운 아이콘 컨테이너 높이 맞춤
+  }),
+  menu: (provided: any) => ({
+    ...provided,
+    maxHeight: "150px", // 옵션 목록의 최대 높이 설정
+  }),
+  menuList: (provided: any) => ({
+    ...provided,
+    maxHeight: "70px", // 옵션 목록의 최대 높이 설정
+    overflowY: "auto", // 스크롤 설정
+  }),
+};
+
+export default function RangeSelectBar({
+  index,
+  count,
+  selected,
+  handleTempSelected,
+}: SelectProps) {
+  const range: { value: number; label: number }[] = [];
+  for (let i = 0; i <= count; i++) {
+    range.push({ value: i, label: i });
+  }
+
+  const onChangeSelected = (selected: any) => {
+    if (
+      selected &&
+      selected.value !== null &&
+      selected &&
+      selected.value !== undefined
+    ) {
+      handleTempSelected(index, selected.value);
+    }
+  };
+  return (
+    <Select
+      options={range}
+      defaultValue={range[selected]}
+      onChange={onChangeSelected}
+      styles={customStyles}
+    />
+  );
+}

--- a/frontend/src/routes/stock/component/SCard.tsx
+++ b/frontend/src/routes/stock/component/SCard.tsx
@@ -1,0 +1,86 @@
+import styled from "styled-components";
+import StockSelectBar from "./StockSelectBar";
+
+interface CardProps {
+  index: number;
+  stockInfo: [
+    number,
+    string,
+    string,
+    string,
+    string,
+    number,
+    number,
+    number,
+    number,
+    string
+  ];
+  handleSelectedStock: (index: number, amount: number) => void;
+}
+
+interface ColorProps {
+  bgColor: string;
+}
+
+const colors = [
+  "#f7e8bc",
+  "#9abade",
+  "#f7bcea",
+  "#caf7bc",
+  "#b2de9a",
+  "#de9abd",
+];
+
+const getRandomColor = () => {
+  return colors[Math.floor(Math.random() * colors.length)];
+};
+
+const StyledCard = styled.div<ColorProps>`
+  border-radius: 20px;
+  padding: 20px;
+  width: 316px;
+  height: 200px;
+  //background-color: #9abade;
+  background-color: ${(props) => props.bgColor}; /* 랜덤 색상을 설정 */
+  box-shadow: 1px 2px 3px rgba(0, 0, 0, 0.1);
+  margin: 0 10px; /* 카드 사이의 간격을 넓힘 */
+`;
+
+export default function SCard({
+  index,
+  stockInfo,
+  handleSelectedStock,
+}: CardProps) {
+  return (
+    //회사코드, 회사명, 종목명, 등급, 전일종가, 선택한 주수, 전체 주수, 한도, 계좌번호
+    <StyledCard bgColor={getRandomColor()}>
+      <div className="flex flex-col gap-1.5">
+        <div className="flex justify-between">
+          <p className="font-bold">{stockInfo[3]}</p>{" "}
+          <p>전일 종가 {stockInfo[5]}원</p>
+        </div>
+        <div className="flex justify-between">
+          <p className="font-bold text-red-700	">{stockInfo[4]}등급</p>
+          <p>총 주수 {stockInfo[7]}주</p>
+        </div>
+        <div className="flex justify-end gap-3 items-center	">
+          <div>주수 선택 </div>
+          <div className="w-1/3">
+            <StockSelectBar
+              index={index}
+              count={stockInfo[7]}
+              amount={stockInfo[6]}
+              handleSelectedStock={handleSelectedStock}
+            />
+          </div>
+        </div>
+        <div className="flex flex-row-reverse">
+          <p>총 가격 {stockInfo[5] * stockInfo[7]}원</p>
+        </div>
+        <div className="flex flex-row-reverse">
+          <p>확보 가능한 최대 한도 {stockInfo[8] * stockInfo[7]}원</p>
+        </div>
+      </div>
+    </StyledCard>
+  );
+}

--- a/frontend/src/routes/stock/component/SelectedStockButtonbar.tsx
+++ b/frontend/src/routes/stock/component/SelectedStockButtonbar.tsx
@@ -1,0 +1,36 @@
+import BasicButton from "../../../components/button/BasicButton";
+
+interface ButtonProps {
+  handlePage: (p: number) => void;
+  clickFinishButton: () => void;
+}
+
+export default function SelectedStockButtonbar({
+  handlePage,
+  clickFinishButton,
+}: ButtonProps) {
+  return (
+    <div
+      className="flex justify-between
+    "
+    >
+      <BasicButton
+        type="gray"
+        onClick={() => {
+          handlePage(0);
+        }}
+      >
+        이전
+      </BasicButton>
+      <BasicButton
+        type="blue"
+        onClick={() => {
+          clickFinishButton();
+          handlePage(0);
+        }}
+      >
+        완료
+      </BasicButton>
+    </div>
+  );
+}

--- a/frontend/src/routes/stock/component/StockFrame.tsx
+++ b/frontend/src/routes/stock/component/StockFrame.tsx
@@ -1,0 +1,191 @@
+import { useEffect, useState } from "react";
+import BoldTitle from "../../../components/text/BoldTitle";
+import BackgroundFrame from "../../../components/backgroundframe/BackgroundFrame";
+import StockModal from "./StockModal";
+
+interface StockProps {
+  stocks: [
+    string,
+    string,
+    string,
+    string,
+    number,
+    number,
+    number,
+    number,
+    string
+  ][];
+  handleTemp: (index: number, amount: number) => void;
+}
+export default function StockFrame({ stocks, handleTemp }: StockProps) {
+  // 0       1      2    3     4        5        6       7     8
+  //회사코드, 회사명, 종목명, 등급, 전일종가, 선택한 주수, 전체 주수, 한도, 계좌번호
+
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [clickedValue, setClickedValue] = useState<number>(0);
+  const [maxValue, setMaxValue] = useState<number>(0);
+  const [nowIndex, setNowIndex] = useState<number>(0);
+  const openModal = () => setIsModalOpen(true);
+  const closeModal = () => setIsModalOpen(false);
+
+  const [category, setCategory] = useState<{
+    [key: string]: [
+      number,
+      string,
+      string,
+      string,
+      string,
+      number,
+      number,
+      number,
+      number,
+      string
+    ][];
+  }>({});
+
+  const handleCategory = (
+    arr: [
+      string,
+      string,
+      string,
+      string,
+      number,
+      number,
+      number,
+      number,
+      string
+    ][]
+  ) => {
+    const grouped: {
+      [key: string]: [
+        number,
+        string,
+        string,
+        string,
+        string,
+        number,
+        number,
+        number,
+        number,
+        string
+      ][];
+    } = {};
+
+    arr.forEach((stock, index) => {
+      const key = stock[1];
+      const newStock: [
+        number,
+        string,
+        string,
+        string,
+        string,
+        number,
+        number,
+        number,
+        number,
+        string
+      ] = [index, ...stock];
+
+      //이미 해당 증권사 그룹이 생성돼있다면,
+      if (grouped[key]) {
+        grouped[key].push(newStock);
+      } else {
+        grouped[key] = [newStock];
+      }
+    });
+
+    return grouped;
+  };
+  useEffect(() => {
+    setCategory(handleCategory(stocks));
+  }, [stocks]);
+
+  useEffect(() => {
+    console.log("잘 필터링되는지 확인");
+    console.log(category);
+  }, [category]);
+
+  const handleOpenModal = (index: number, value: number, max: number) => {
+    setClickedValue(value);
+    setMaxValue(max);
+    setNowIndex(index);
+    openModal();
+  };
+
+  const handleCloseModal = () => {
+    setClickedValue(0);
+    setMaxValue(0);
+    setNowIndex(0);
+    closeModal();
+  };
+
+  return (
+    <div>
+      <div>
+        {Object.entries(category).map(([key, stocks]) => (
+          <div>
+            <BoldTitle>{key}</BoldTitle>
+            <BackgroundFrame color="blue">
+              <div className="text-sm">
+                <table
+                  style={{
+                    width: "100%",
+                    borderCollapse: "collapse",
+                    textAlign: "center",
+                  }}
+                >
+                  <thead>
+                    <tr>
+                      <th>증권사명</th>
+                      <th>종목명</th>
+                      <th>선택한 주수</th>
+                      <th>전일 종가</th>
+                      <th>등급</th>
+                      <th>가능 한도</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {stocks.map((stock, index) =>
+                      stock[6] !== 0 ? (
+                        <tr
+                          key={index}
+                          onClick={() =>
+                            handleOpenModal(stock[0], stock[6], stock[7])
+                          }
+                          style={{
+                            cursor: "pointer",
+                          }}
+                        >
+                          <td>{stock[2]}</td>
+                          <td>{stock[3]}</td>
+                          <td>{stock[6]}</td>
+                          <td>{stock[5]}</td>
+                          <td>{stock[4]}</td>
+                          <td>{stock[8]}</td>
+                          <div></div>
+                        </tr>
+                      ) : (
+                        <div></div>
+                      )
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </BackgroundFrame>
+          </div>
+        ))}
+      </div>
+
+      {isModalOpen && (
+        <StockModal
+          index={nowIndex}
+          amount={clickedValue}
+          max={maxValue}
+          isModalOpen={isModalOpen}
+          onCloseModal={handleCloseModal}
+          handleTemp={handleTemp}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/routes/stock/component/StockFrame.tsx
+++ b/frontend/src/routes/stock/component/StockFrame.tsx
@@ -136,7 +136,6 @@ export default function StockFrame({ stocks, handleTemp }: StockProps) {
                 >
                   <thead>
                     <tr>
-                      <th>증권사명</th>
                       <th>종목명</th>
                       <th>선택한 주수</th>
                       <th>전일 종가</th>
@@ -156,7 +155,6 @@ export default function StockFrame({ stocks, handleTemp }: StockProps) {
                             cursor: "pointer",
                           }}
                         >
-                          <td>{stock[2]}</td>
                           <td>{stock[3]}</td>
                           <td>{stock[6]}</td>
                           <td>{stock[5]}</td>

--- a/frontend/src/routes/stock/component/StockModal.tsx
+++ b/frontend/src/routes/stock/component/StockModal.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+import BasicModal from "../../../components/modal/BasicModal";
+import XButton from "../../../components/button/XButton";
+import BasicButton from "../../../components/button/BasicButton";
+import RangeSelectBar from "./RangeSelectBar";
+
+interface ModalProps {
+  index: number;
+  amount: number;
+  max: number;
+  isModalOpen: boolean;
+  onCloseModal: () => void;
+  handleTemp: (index: number, amount: number) => void;
+}
+
+export default function StockModal({
+  index,
+  amount,
+  max,
+  isModalOpen,
+  onCloseModal,
+  handleTemp,
+}: ModalProps) {
+  const [tempSelected, setTempSelected] = useState<[number, number]>([
+    index,
+    amount,
+  ]);
+
+  const handleTempSelected = (index: number, amount: number) => {
+    if (amount !== null) setTempSelected([index, amount]);
+  };
+
+  const handleDeleteButton = () => {
+    handleTemp(index, 0);
+    onCloseModal();
+  };
+
+  const handleFinishButton = () => {
+    handleTemp(tempSelected[0], tempSelected[1]);
+    onCloseModal();
+  };
+
+  return (
+    <BasicModal isOpen={isModalOpen} onRequestClose={onCloseModal}>
+      <div className="flex flex-row-reverse">
+        <span onClick={onCloseModal}>
+          <XButton />
+        </span>
+      </div>
+      <h2>선택한 주수: {amount}</h2>
+      <h2>
+        수정할 주수:
+        <p className="w-1/3">
+          <RangeSelectBar
+            index={index}
+            count={max}
+            selected={amount}
+            handleTempSelected={handleTempSelected}
+          />
+        </p>
+      </h2>
+      <BasicButton onClick={handleDeleteButton}>삭제</BasicButton>
+      <BasicButton onClick={handleFinishButton}>완료</BasicButton>
+    </BasicModal>
+  );
+}

--- a/frontend/src/routes/stock/component/StockSelectBar.tsx
+++ b/frontend/src/routes/stock/component/StockSelectBar.tsx
@@ -1,0 +1,72 @@
+import Select from "react-select";
+
+interface SelectProps {
+  index: number;
+  count: number;
+  amount: number;
+  handleSelectedStock: (index: number, amount: number) => void;
+}
+
+const customStyles = {
+  control: (provided: any) => ({
+    ...provided,
+    minHeight: "100%", // control 높이를 부모 div 높이에 맞춤
+    height: "100%", // 고정 높이
+  }),
+  valueContainer: (provided: any) => ({
+    ...provided,
+    height: "100%", // 내부 값 컨테이너 높이를 맞춤
+    padding: "0 8px",
+  }),
+  input: (provided: any) => ({
+    ...provided,
+    margin: "0px",
+  }),
+  indicatorsContainer: (provided: any) => ({
+    ...provided,
+    height: "100%", // 드롭다운 아이콘 컨테이너 높이 맞춤
+  }),
+  menu: (provided: any) => ({
+    ...provided,
+    maxHeight: "150px", // 옵션 목록의 최대 높이 설정
+  }),
+  menuList: (provided: any) => ({
+    ...provided,
+    maxHeight: "70px", // 옵션 목록의 최대 높이 설정
+    overflowY: "auto", // 스크롤 설정
+  }),
+};
+
+export default function StockSelectBar({
+  index,
+  count,
+  amount,
+  handleSelectedStock,
+}: SelectProps) {
+  const range: { value: number; label: number }[] = [];
+  for (let i = 0; i <= count; i++) {
+    range.push({ value: i, label: i });
+  }
+
+  console.log("선택한 주식량" + amount);
+  const onChangeSelected = (selected: any) => {
+    console.log("onChangeSelected");
+    if (
+      selected &&
+      selected.value !== null &&
+      selected &&
+      selected.value !== undefined
+    ) {
+      handleSelectedStock(index, selected.value);
+    }
+  };
+
+  return (
+    <Select
+      options={range}
+      value={range[amount]}
+      onChange={onChangeSelected}
+      styles={customStyles}
+    />
+  );
+}

--- a/frontend/src/routes/stockcheck/StockCheckPage.tsx
+++ b/frontend/src/routes/stockcheck/StockCheckPage.tsx
@@ -80,18 +80,16 @@ export default function StockCheckPage() {
       gotStock.map((row, index) => {
         handleSelectedCountList(index, row[2]);
       });
-
-      // console.log("넘어옴!");
     }
   }, [location.state]);
 
-  // useEffect(() => {
-  //   console.log(selectedStock);
-  // }, [selectedStock]);
+  useEffect(() => {
+    console.log(selectedStock);
+  }, [selectedStock]);
 
   let totalLimit = 0;
   for (let i = 0; i < stocks.length; i++) {
-    totalLimit += stocks[i][4] * stocks[i][3];
+    totalLimit += stocks[i][4] * stocks[i][2];
   }
 
   return (

--- a/frontend/src/routes/stockcheck/StockCheckPage.tsx
+++ b/frontend/src/routes/stockcheck/StockCheckPage.tsx
@@ -1,16 +1,39 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import ButtonBar from "../../components/button/ButtonBar";
 import QuestionButton from "../../components/button/QuestionButton";
 import PaddingDiv from "../../components/settingdiv/PaddingDiv";
 import BoldTitle from "../../components/text/BoldTitle";
 import CardList from "./component/CardList";
 import StockLevelModal from "./component/StockLevelModal";
+import MoveButton from "../../components/button/MoveButton";
 
 export default function StockCheckPage() {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const navigate = useNavigate();
 
   const openModal = () => setIsModalOpen(true);
   const closeModal = () => setIsModalOpen(false);
+
+  //TODO: 이거 백엔드에서 받아온 증권 정보들
+  //종목명, 등급, 보유주수, 전일종가, 최대한도
+  const stocks: [string, string, number, number, number][] = [
+    ["삼성전자", "A", 30, 70000, 1200000],
+    ["엘지전자", "A", 50, 50000, 1200000],
+    ["하이닉스", "A", 40, 80000, 1200000],
+    ["종근당", "A", 20, 20000, 1200000],
+    ["현대오토에버", "A", 20, 60000, 1200000],
+  ];
+
+  let totalLimit = 0;
+  for (let i = 0; i < stocks.length; i++) {
+    totalLimit += stocks[i][4];
+  }
+
+  //TODO: 주식 자동 선택 api 요청 보내기
+  const autoSelect = () => {
+    navigate("/selectedstock");
+  };
 
   return (
     <PaddingDiv>
@@ -29,13 +52,36 @@ export default function StockCheckPage() {
         </div>
       </div>
 
-      <CardList />
-      <ButtonBar
-        beforetext="이전"
-        nexttext="다음"
-        beforeurl="/serviceagree"
-        nexturl="/"
-      ></ButtonBar>
+      <CardList stocks={stocks} />
+
+      <div>
+        <div className="mb-5">
+          <div className="flex justify-between mb-5">
+            <BoldTitle>
+              확보 가능한 최대 한도: <br />
+              {totalLimit} 원
+            </BoldTitle>
+            <MoveButton
+              onClick={() => {
+                navigate("/selectedstock");
+              }}
+            >
+              선택한 주식 보기
+            </MoveButton>
+          </div>
+          {/*이거 클릭 시에 api 요청 보내고 선택된 값 받아와서 selected stock 페이지 띄우기*/}
+          <div onClick={autoSelect} className="text-sm	text-blue-700">
+            원하는 한도에 맞게 주식을 자동으로 선택해주세요.
+          </div>
+        </div>
+
+        <ButtonBar
+          beforetext="이전"
+          nexttext="다음"
+          beforeurl="/serviceagree"
+          nexturl="/priority"
+        ></ButtonBar>
+      </div>
     </PaddingDiv>
   );
 }

--- a/frontend/src/routes/stockcheck/StockCheckPage.tsx
+++ b/frontend/src/routes/stockcheck/StockCheckPage.tsx
@@ -79,9 +79,21 @@ export default function StockCheckPage() {
         gotStock: [string, string, number, number, number][];
       };
 
-      gotStock.map((row, index) => {
-        handleSelectedCountList(index, row[2]);
-      });
+      const { priorityToCheck } = location.state as {
+        priorityToCheck: [string, string, number, number, number][];
+      };
+
+      if (gotStock && Array.isArray(gotStock)) {
+        gotStock.map((row, index) => {
+          handleSelectedCountList(index, row[2]);
+        });
+      }
+
+      if (priorityToCheck && Array.isArray(priorityToCheck)) {
+        priorityToCheck.map((row, index) => {
+          handleSelectedCountList(index, row[2]);
+        });
+      }
     }
   }, [location.state]);
 
@@ -121,7 +133,7 @@ export default function StockCheckPage() {
         <div className="mb-5">
           <div className="flex justify-between mb-5">
             <BoldTitle>
-              확보 가능한 최대 한도: <br />
+              현재 확보 가능한 최대 한도: <br />
               {totalLimit} 원
             </BoldTitle>
             <MoveButton

--- a/frontend/src/routes/stockcheck/StockCheckPage.tsx
+++ b/frontend/src/routes/stockcheck/StockCheckPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import ButtonBar from "../../components/button/ButtonBar";
 import QuestionButton from "../../components/button/QuestionButton";
@@ -10,20 +10,51 @@ import MoveButton from "../../components/button/MoveButton";
 
 export default function StockCheckPage() {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  //TODO: 이거 백엔드에서 받아온 증권 정보들
+  //종목명, 등급, 보유주수, 전일종가, 단위별 가능한도
+  const stocks: [string, string, number, number, number][] = [
+    ["삼성전자", "A", 30, 70000, 12000],
+    ["엘지전자", "A", 50, 50000, 12000],
+    ["하이닉스", "A", 40, 80000, 12000],
+    ["종근당", "A", 20, 20000, 12000],
+    ["현대오토에버", "A", 20, 60000, 12000],
+  ];
+  const [selectedCountList, setSelectedCountList] = useState<number[]>(() =>
+    Array(stocks.length).fill(0)
+  );
+  const [selectedStock, setSelectedStock] = useState<
+    [string, string, number, number, number][]
+  >([...stocks]);
   const navigate = useNavigate();
 
   const openModal = () => setIsModalOpen(true);
   const closeModal = () => setIsModalOpen(false);
 
-  //TODO: 이거 백엔드에서 받아온 증권 정보들
-  //종목명, 등급, 보유주수, 전일종가, 최대한도
-  const stocks: [string, string, number, number, number][] = [
-    ["삼성전자", "A", 30, 70000, 1200000],
-    ["엘지전자", "A", 50, 50000, 1200000],
-    ["하이닉스", "A", 40, 80000, 1200000],
-    ["종근당", "A", 20, 20000, 1200000],
-    ["현대오토에버", "A", 20, 60000, 1200000],
-  ];
+  //선택주수 배열 업데이트
+  const handleSelectedCountList = (index: number, newCount: number) => {
+    setSelectedCountList((prevArray) => [
+      ...prevArray.slice(0, index),
+      newCount,
+      ...prevArray.slice(index + 1),
+    ]);
+  };
+
+  const updateSelectedStock = useCallback(() => {
+    setSelectedStock((prevSelectedStock) => {
+      const updatedSelectedStock = selectedStock.map((prevRow, index) => {
+        const updateRow: [string, string, number, number, number] = [
+          ...prevRow,
+        ];
+        updateRow[2] = selectedCountList[index];
+        return updateRow;
+      });
+      return updatedSelectedStock;
+    });
+  }, [selectedCountList]);
+
+  useEffect(() => {
+    updateSelectedStock();
+  }, [updateSelectedStock]);
 
   let totalLimit = 0;
   for (let i = 0; i < stocks.length; i++) {
@@ -31,6 +62,7 @@ export default function StockCheckPage() {
   }
 
   //TODO: 주식 자동 선택 api 요청 보내기
+  //아닌가? 내가 하는건가?
   const autoSelect = () => {
     navigate("/selectedstock");
   };
@@ -52,7 +84,10 @@ export default function StockCheckPage() {
         </div>
       </div>
 
-      <CardList stocks={stocks} />
+      <CardList
+        stocks={stocks}
+        handleSelectedCountList={handleSelectedCountList}
+      />
 
       <div>
         <div className="mb-5">

--- a/frontend/src/routes/stockcheck/StockCheckPage.tsx
+++ b/frontend/src/routes/stockcheck/StockCheckPage.tsx
@@ -1,163 +1,163 @@
-import { useCallback, useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
-import { useNavigate } from "react-router-dom";
-import ButtonBar from "../../components/button/ButtonBar";
-import QuestionButton from "../../components/button/QuestionButton";
-import PaddingDiv from "../../components/settingdiv/PaddingDiv";
-import BoldTitle from "../../components/text/BoldTitle";
-import CardList from "./component/CardList";
-import StockLevelModal from "./component/StockLevelModal";
-import MoveButton from "../../components/button/MoveButton";
+// import { useCallback, useEffect, useState } from "react";
+// import { useLocation } from "react-router-dom";
+// import { useNavigate } from "react-router-dom";
+// import ButtonBar from "../../components/button/ButtonBar";
+// import QuestionButton from "../../components/button/QuestionButton";
+// import PaddingDiv from "../../components/settingdiv/PaddingDiv";
+// import BoldTitle from "../../components/text/BoldTitle";
+// import CardList from "./component/CardList";
+// import StockLevelModal from "./component/StockLevelModal";
+// import MoveButton from "../../components/button/MoveButton";
 
-export default function StockCheckPage() {
-  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
-  //TODO: 이거 백엔드에서 받아온 증권 정보들
-  //종목명, 등급, 보유주수, 전일종가, 단위별 가능한도
-  const stocks: [string, string, number, number, number][] = [
-    ["삼성전자", "A", 30, 70000, 12000],
-    ["엘지전자", "A", 50, 50000, 12000],
-    ["하이닉스", "A", 40, 80000, 12000],
-    ["종근당", "A", 20, 20000, 12000],
-    ["현대오토에버", "A", 20, 60000, 12000],
-  ];
-  const [selectedCountList, setSelectedCountList] = useState<number[]>(() =>
-    Array(stocks.length).fill(0)
-  );
-  const [selectedStock, setSelectedStock] = useState<
-    [string, string, number, number, number][]
-  >([...stocks]);
-  const navigate = useNavigate();
+// export default function StockCheckPage() {
+//   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+//   //TODO: 이거 백엔드에서 받아온 증권 정보들
+//   //종목명, 등급, 보유주수, 전일종가, 단위별 가능한도
+//   const stocks: [string, string, number, number, number][] = [
+//     ["삼성전자", "A", 30, 70000, 12000],
+//     ["엘지전자", "A", 50, 50000, 12000],
+//     ["하이닉스", "A", 40, 80000, 12000],
+//     ["종근당", "A", 20, 20000, 12000],
+//     ["현대오토에버", "A", 20, 60000, 12000],
+//   ];
+//   const [selectedCountList, setSelectedCountList] = useState<number[]>(() =>
+//     Array(stocks.length).fill(0)
+//   );
+//   const [selectedStock, setSelectedStock] = useState<
+//     [string, string, number, number, number][]
+//   >([...stocks]);
+//   const navigate = useNavigate();
 
-  const openModal = () => setIsModalOpen(true);
-  const closeModal = () => setIsModalOpen(false);
+//   const openModal = () => setIsModalOpen(true);
+//   const closeModal = () => setIsModalOpen(false);
 
-  //선택주수 배열 업데이트
-  const handleSelectedCountList = (index: number, newCount: number) => {
-    setSelectedCountList((prevArray) => [
-      ...prevArray.slice(0, index),
-      newCount,
-      ...prevArray.slice(index + 1),
-    ]);
-  };
+//   //선택주수 배열 업데이트
+//   const handleSelectedCountList = (index: number, newCount: number) => {
+//     setSelectedCountList((prevArray) => [
+//       ...prevArray.slice(0, index),
+//       newCount,
+//       ...prevArray.slice(index + 1),
+//     ]);
+//   };
 
-  const updateSelectedStock = useCallback(() => {
-    setSelectedStock((/*prevSelectedStock*/) => {
-      const updatedSelectedStock = selectedStock.map((prevRow, index) => {
-        const updateRow: [string, string, number, number, number] = [
-          ...prevRow,
-        ];
-        updateRow[2] = selectedCountList[index];
-        return updateRow;
-      });
-      return updatedSelectedStock;
-    });
-  }, [selectedCountList]);
+//   const updateSelectedStock = useCallback(() => {
+//     setSelectedStock((/*prevSelectedStock*/) => {
+//       const updatedSelectedStock = selectedStock.map((prevRow, index) => {
+//         const updateRow: [string, string, number, number, number] = [
+//           ...prevRow,
+//         ];
+//         updateRow[2] = selectedCountList[index];
+//         return updateRow;
+//       });
+//       return updatedSelectedStock;
+//     });
+//   }, [selectedCountList]);
 
-  useEffect(() => {
-    updateSelectedStock();
-  }, [updateSelectedStock]);
+//   useEffect(() => {
+//     updateSelectedStock();
+//   }, [updateSelectedStock]);
 
-  //TODO: 주식 자동 선택 api 요청 보내기
-  //아닌가? 내가 하는건가?
-  const autoSelect = () => {
-    navigate("/selectedstock");
-  };
+//   //TODO: 주식 자동 선택 api 요청 보내기
+//   //아닌가? 내가 하는건가?
+//   const autoSelect = () => {
+//     navigate("/selectedstock");
+//   };
 
-  //상태 넘겨주고
-  const moveToSelectedPage = () => {
-    navigate("/selectedstock", {
-      state: { selectedStock: selectedStock, stocks: stocks },
-    });
-  };
+//   //상태 넘겨주고
+//   const moveToSelectedPage = () => {
+//     navigate("/selectedstock", {
+//       state: { selectedStock: selectedStock, stocks: stocks },
+//     });
+//   };
 
-  //상태 받기
-  const location = useLocation();
+//   //상태 받기
+//   const location = useLocation();
 
-  useEffect(() => {
-    if (location.state) {
-      const { gotStock } = location.state as {
-        gotStock: [string, string, number, number, number][];
-      };
+//   useEffect(() => {
+//     if (location.state) {
+//       const { gotStock } = location.state as {
+//         gotStock: [string, string, number, number, number][];
+//       };
 
-      const { priorityToCheck } = location.state as {
-        priorityToCheck: [string, string, number, number, number][];
-      };
+//       const { priorityToCheck } = location.state as {
+//         priorityToCheck: [string, string, number, number, number][];
+//       };
 
-      if (gotStock && Array.isArray(gotStock)) {
-        gotStock.map((row, index) => {
-          handleSelectedCountList(index, row[2]);
-        });
-      }
+//       if (gotStock && Array.isArray(gotStock)) {
+//         gotStock.map((row, index) => {
+//           handleSelectedCountList(index, row[2]);
+//         });
+//       }
 
-      if (priorityToCheck && Array.isArray(priorityToCheck)) {
-        priorityToCheck.map((row, index) => {
-          handleSelectedCountList(index, row[2]);
-        });
-      }
-    }
-  }, [location.state]);
+//       if (priorityToCheck && Array.isArray(priorityToCheck)) {
+//         priorityToCheck.map((row, index) => {
+//           handleSelectedCountList(index, row[2]);
+//         });
+//       }
+//     }
+//   }, [location.state]);
 
-  useEffect(() => {
-    console.log(selectedStock);
-  }, [selectedStock]);
+//   useEffect(() => {
+//     console.log(selectedStock);
+//   }, [selectedStock]);
 
-  let totalLimit = 0;
-  for (let i = 0; i < stocks.length; i++) {
-    totalLimit += stocks[i][4] * stocks[i][2];
-  }
+//   let totalLimit = 0;
+//   for (let i = 0; i < stocks.length; i++) {
+//     totalLimit += stocks[i][4] * stocks[i][2];
+//   }
 
-  return (
-    <PaddingDiv>
-      <div className="flex justify-between">
-        <BoldTitle>담보로 잡을 주식을 선택해주세요.</BoldTitle>
-        <div>
-          <div onClick={openModal}>
-            <QuestionButton />
-          </div>
-          {isModalOpen && (
-            <StockLevelModal
-              isModalOpen={isModalOpen}
-              handleCloseModal={closeModal}
-            />
-          )}
-        </div>
-      </div>
+//   return (
+//     <PaddingDiv>
+//       <div className="flex justify-between">
+//         <BoldTitle>담보로 잡을 주식을 선택해주세요.</BoldTitle>
+//         <div>
+//           <div onClick={openModal}>
+//             <QuestionButton />
+//           </div>
+//           {isModalOpen && (
+//             <StockLevelModal
+//               isModalOpen={isModalOpen}
+//               handleCloseModal={closeModal}
+//             />
+//           )}
+//         </div>
+//       </div>
 
-      <CardList
-        stocks={stocks}
-        handleSelectedCountList={handleSelectedCountList}
-        selectedCountList={selectedCountList}
-      />
+//       <CardList
+//         stocks={stocks}
+//         handleSelectedCountList={handleSelectedCountList}
+//         selectedCountList={selectedCountList}
+//       />
 
-      <div>
-        <div className="mb-5">
-          <div className="flex justify-between mb-5">
-            <BoldTitle>
-              현재 확보 가능한 최대 한도: <br />
-              {totalLimit} 원
-            </BoldTitle>
-            <MoveButton
-              onClick={() => {
-                moveToSelectedPage();
-              }}
-            >
-              선택한 주식 보기
-            </MoveButton>
-          </div>
-          {/*이거 클릭 시에 api 요청 보내고 선택된 값 받아와서 selected stock 페이지 띄우기*/}
-          <div onClick={autoSelect} className="text-sm	text-blue-700">
-            원하는 한도에 맞게 주식을 자동으로 선택해주세요.
-          </div>
-        </div>
+//       <div>
+//         <div className="mb-5">
+//           <div className="flex justify-between mb-5">
+//             <BoldTitle>
+//               현재 확보 가능한 최대 한도: <br />
+//               {totalLimit} 원
+//             </BoldTitle>
+//             <MoveButton
+//               onClick={() => {
+//                 moveToSelectedPage();
+//               }}
+//             >
+//               선택한 주식 보기
+//             </MoveButton>
+//           </div>
+//           {/*이거 클릭 시에 api 요청 보내고 선택된 값 받아와서 selected stock 페이지 띄우기*/}
+//           <div onClick={autoSelect} className="text-sm	text-blue-700">
+//             원하는 한도에 맞게 주식을 자동으로 선택해주세요.
+//           </div>
+//         </div>
 
-        <ButtonBar
-          beforetext="이전"
-          nexttext="다음"
-          beforeurl="/serviceagree"
-          nexturl="/priority"
-          nextstate={{ selectedStock: selectedStock, stocks: stocks }}
-        ></ButtonBar>
-      </div>
-    </PaddingDiv>
-  );
-}
+//         <ButtonBar
+//           beforetext="이전"
+//           nexttext="다음"
+//           beforeurl="/serviceagree"
+//           nexturl="/priority"
+//           nextstate={{ selectedStock: selectedStock, stocks: stocks }}
+//         ></ButtonBar>
+//       </div>
+//     </PaddingDiv>
+//   );
+// }

--- a/frontend/src/routes/stockcheck/StockCheckPage.tsx
+++ b/frontend/src/routes/stockcheck/StockCheckPage.tsx
@@ -41,7 +41,7 @@ export default function StockCheckPage() {
   };
 
   const updateSelectedStock = useCallback(() => {
-    setSelectedStock((prevSelectedStock) => {
+    setSelectedStock((/*prevSelectedStock*/) => {
       const updatedSelectedStock = selectedStock.map((prevRow, index) => {
         const updateRow: [string, string, number, number, number] = [
           ...prevRow,
@@ -65,7 +65,9 @@ export default function StockCheckPage() {
 
   //상태 넘겨주고
   const moveToSelectedPage = () => {
-    navigate("/selectedstock", { state: { selectedStock: selectedStock } });
+    navigate("/selectedstock", {
+      state: { selectedStock: selectedStock, stocks: stocks },
+    });
   };
 
   //상태 받기
@@ -112,6 +114,7 @@ export default function StockCheckPage() {
       <CardList
         stocks={stocks}
         handleSelectedCountList={handleSelectedCountList}
+        selectedCountList={selectedCountList}
       />
 
       <div>
@@ -140,7 +143,7 @@ export default function StockCheckPage() {
           nexttext="다음"
           beforeurl="/serviceagree"
           nexturl="/priority"
-          nextstate={{ selectedStock: selectedStock }}
+          nextstate={{ selectedStock: selectedStock, stocks: stocks }}
         ></ButtonBar>
       </div>
     </PaddingDiv>

--- a/frontend/src/routes/stockcheck/StockCheckPage.tsx
+++ b/frontend/src/routes/stockcheck/StockCheckPage.tsx
@@ -29,7 +29,7 @@ export default function StockCheckPage() {
         </div>
       </div>
 
-      <CardList></CardList>
+      <CardList />
       <ButtonBar
         beforetext="이전"
         nexttext="다음"

--- a/frontend/src/routes/stockcheck/StockCheckPage.tsx
+++ b/frontend/src/routes/stockcheck/StockCheckPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
 import { useNavigate } from "react-router-dom";
 import ButtonBar from "../../components/button/ButtonBar";
 import QuestionButton from "../../components/button/QuestionButton";
@@ -56,16 +57,42 @@ export default function StockCheckPage() {
     updateSelectedStock();
   }, [updateSelectedStock]);
 
-  let totalLimit = 0;
-  for (let i = 0; i < stocks.length; i++) {
-    totalLimit += stocks[i][4];
-  }
-
   //TODO: 주식 자동 선택 api 요청 보내기
   //아닌가? 내가 하는건가?
   const autoSelect = () => {
     navigate("/selectedstock");
   };
+
+  //상태 넘겨주고
+  const moveToSelectedPage = () => {
+    navigate("/selectedstock", { state: { selectedStock: selectedStock } });
+  };
+
+  //상태 받기
+  const location = useLocation();
+
+  useEffect(() => {
+    if (location.state) {
+      const { gotStock } = location.state as {
+        gotStock: [string, string, number, number, number][];
+      };
+
+      gotStock.map((row, index) => {
+        handleSelectedCountList(index, row[2]);
+      });
+
+      // console.log("넘어옴!");
+    }
+  }, [location.state]);
+
+  // useEffect(() => {
+  //   console.log(selectedStock);
+  // }, [selectedStock]);
+
+  let totalLimit = 0;
+  for (let i = 0; i < stocks.length; i++) {
+    totalLimit += stocks[i][4] * stocks[i][3];
+  }
 
   return (
     <PaddingDiv>
@@ -98,7 +125,7 @@ export default function StockCheckPage() {
             </BoldTitle>
             <MoveButton
               onClick={() => {
-                navigate("/selectedstock");
+                moveToSelectedPage();
               }}
             >
               선택한 주식 보기
@@ -115,6 +142,7 @@ export default function StockCheckPage() {
           nexttext="다음"
           beforeurl="/serviceagree"
           nexturl="/priority"
+          nextstate={{ selectedStock: selectedStock }}
         ></ButtonBar>
       </div>
     </PaddingDiv>

--- a/frontend/src/routes/stockcheck/component/CardList.tsx
+++ b/frontend/src/routes/stockcheck/component/CardList.tsx
@@ -42,7 +42,7 @@ export default function CardList({ stocks }: StockProps) {
         <NormalTitle>신한투자증권</NormalTitle>
         <Wrapper>
           <Slider {...settings}>
-            {cards.map((card) => (
+            {cards.map((card, index) => (
               <StockCard
                 stockName={card[0]}
                 stockLevel={card[1]}
@@ -54,22 +54,6 @@ export default function CardList({ stocks }: StockProps) {
           </Slider>
         </Wrapper>
       </div>
-      {/* <div>
-        <NormalTitle>NH투자증권</NormalTitle>
-        <Wrapper>
-          <Slider {...settings}>
-            {cards.map((card) => (
-              <StockCard
-                stockName={card[0]}
-                stockLevel={card[1]}
-                stockCount={card[2]}
-                stockPrice={card[3]}
-                limit={card[4]}
-              />
-            ))}
-          </Slider>
-        </Wrapper>
-      </div> */}
     </div>
   );
 }

--- a/frontend/src/routes/stockcheck/component/CardList.tsx
+++ b/frontend/src/routes/stockcheck/component/CardList.tsx
@@ -5,6 +5,7 @@ import StockCard from "./StockCard";
 
 interface StockProps {
   stocks: [string, string, number, number, number][];
+  handleSelectedCountList: (index: number, newCount: number) => void;
 }
 
 const Wrapper = styled.div`
@@ -19,7 +20,10 @@ const Wrapper = styled.div`
 
 //TODO: 선택한 주식 저장하는 로직 저장
 
-export default function CardList({ stocks }: StockProps) {
+export default function CardList({
+  stocks,
+  handleSelectedCountList,
+}: StockProps) {
   const settings = {
     infinite: false,
     centerMode: true,
@@ -44,11 +48,13 @@ export default function CardList({ stocks }: StockProps) {
           <Slider {...settings}>
             {cards.map((card, index) => (
               <StockCard
+                stockId={index}
                 stockName={card[0]}
                 stockLevel={card[1]}
                 stockCount={card[2]}
                 stockPrice={card[3]}
                 limit={card[4]}
+                handleSelectedCountList={handleSelectedCountList}
               />
             ))}
           </Slider>

--- a/frontend/src/routes/stockcheck/component/CardList.tsx
+++ b/frontend/src/routes/stockcheck/component/CardList.tsx
@@ -6,6 +6,7 @@ import StockCard from "./StockCard";
 interface StockProps {
   stocks: [string, string, number, number, number][];
   handleSelectedCountList: (index: number, newCount: number) => void;
+  selectedCountList: number[];
 }
 
 const Wrapper = styled.div`
@@ -23,6 +24,7 @@ const Wrapper = styled.div`
 export default function CardList({
   stocks,
   handleSelectedCountList,
+  selectedCountList,
 }: StockProps) {
   const settings = {
     infinite: false,
@@ -55,6 +57,7 @@ export default function CardList({
                 stockPrice={card[3]}
                 limit={card[4]}
                 handleSelectedCountList={handleSelectedCountList}
+                selected={selectedCountList[index]}
               />
             ))}
           </Slider>

--- a/frontend/src/routes/stockcheck/component/CardList.tsx
+++ b/frontend/src/routes/stockcheck/component/CardList.tsx
@@ -15,7 +15,7 @@ const Wrapper = styled.div`
 
 export default function CardList() {
   const settings = {
-    infinite: true,
+    infinite: false,
     centerMode: true,
     centerPadding: "25px",
     slidesToShow: 1,

--- a/frontend/src/routes/stockcheck/component/CardList.tsx
+++ b/frontend/src/routes/stockcheck/component/CardList.tsx
@@ -3,6 +3,10 @@ import Slider from "react-slick";
 import styled from "styled-components";
 import StockCard from "./StockCard";
 
+interface StockProps {
+  stocks: [string, string, number, number, number][];
+}
+
 const Wrapper = styled.div`
   position: relative;
   margin-left: -5%;
@@ -13,7 +17,9 @@ const Wrapper = styled.div`
   }
 `;
 
-export default function CardList() {
+//TODO: 선택한 주식 저장하는 로직 저장
+
+export default function CardList({ stocks }: StockProps) {
   const settings = {
     infinite: false,
     centerMode: true,
@@ -28,13 +34,7 @@ export default function CardList() {
     touchThreshold: 10, // 터치 감도 조정
   };
 
-  const cards: [string, string, number, number, number][] = [
-    ["삼성전자", "A", 30, 70000, 1200000],
-    ["엘지전자", "A", 50, 50000, 1200000],
-    ["하이닉스", "A", 40, 80000, 1200000],
-    ["종근당", "A", 20, 20000, 1200000],
-    ["현대오토에버", "A", 20, 60000, 1200000],
-  ];
+  const cards: [string, string, number, number, number][] = stocks;
 
   return (
     <div className="flex flex-col gap-10">
@@ -54,7 +54,7 @@ export default function CardList() {
           </Slider>
         </Wrapper>
       </div>
-      <div>
+      {/* <div>
         <NormalTitle>NH투자증권</NormalTitle>
         <Wrapper>
           <Slider {...settings}>
@@ -69,7 +69,7 @@ export default function CardList() {
             ))}
           </Slider>
         </Wrapper>
-      </div>
+      </div> */}
     </div>
   );
 }

--- a/frontend/src/routes/stockcheck/component/CardList.tsx
+++ b/frontend/src/routes/stockcheck/component/CardList.tsx
@@ -1,68 +1,68 @@
-import NormalTitle from "../../../components/text/NormalTitle";
-import Slider from "react-slick";
-import styled from "styled-components";
-import StockCard from "./StockCard";
+// import NormalTitle from "../../../components/text/NormalTitle";
+// import Slider from "react-slick";
+// import styled from "styled-components";
+// import StockCard from "./StockCard";
 
-interface StockProps {
-  stocks: [string, string, number, number, number][];
-  handleSelectedCountList: (index: number, newCount: number) => void;
-  selectedCountList: number[];
-}
+// interface StockProps {
+//   stocks: [string, string, number, number, number][];
+//   handleSelectedCountList: (index: number, newCount: number) => void;
+//   selectedCountList: number[];
+// }
 
-const Wrapper = styled.div`
-  position: relative;
-  margin-left: -5%;
-  margin-right: -5%;
+// const Wrapper = styled.div`
+//   position: relative;
+//   margin-left: -5%;
+//   margin-right: -5%;
 
-  .slick-slide {
-    transition: transform 0.3s ease;
-  }
-`;
+//   .slick-slide {
+//     transition: transform 0.3s ease;
+//   }
+// `;
 
-//TODO: 선택한 주식 저장하는 로직 저장
+// //TODO: 선택한 주식 저장하는 로직 저장
 
-export default function CardList({
-  stocks,
-  handleSelectedCountList,
-  selectedCountList,
-}: StockProps) {
-  const settings = {
-    infinite: false,
-    centerMode: true,
-    centerPadding: "25px",
-    slidesToShow: 1,
-    speed: 500,
-    focusOnSelect: true,
-    dots: true,
-    arrows: false,
-    draggable: true, // 드래그 가능 설정
-    swipe: true, // 터치 제스처 스와이프 설정
-    touchThreshold: 10, // 터치 감도 조정
-  };
+// export default function CardList({
+//   stocks,
+//   handleSelectedCountList,
+//   selectedCountList,
+// }: StockProps) {
+//   const settings = {
+//     infinite: false,
+//     centerMode: true,
+//     centerPadding: "25px",
+//     slidesToShow: 1,
+//     speed: 500,
+//     focusOnSelect: true,
+//     dots: true,
+//     arrows: false,
+//     draggable: true, // 드래그 가능 설정
+//     swipe: true, // 터치 제스처 스와이프 설정
+//     touchThreshold: 10, // 터치 감도 조정
+//   };
 
-  const cards: [string, string, number, number, number][] = stocks;
+//   const cards: [string, string, number, number, number][] = stocks;
 
-  return (
-    <div className="flex flex-col gap-10">
-      <div>
-        <NormalTitle>신한투자증권</NormalTitle>
-        <Wrapper>
-          <Slider {...settings}>
-            {cards.map((card, index) => (
-              <StockCard
-                stockId={index}
-                stockName={card[0]}
-                stockLevel={card[1]}
-                stockCount={card[2]}
-                stockPrice={card[3]}
-                limit={card[4]}
-                handleSelectedCountList={handleSelectedCountList}
-                selected={selectedCountList[index]}
-              />
-            ))}
-          </Slider>
-        </Wrapper>
-      </div>
-    </div>
-  );
-}
+//   return (
+//     <div className="flex flex-col gap-10">
+//       <div>
+//         <NormalTitle>신한투자증권</NormalTitle>
+//         <Wrapper>
+//           <Slider {...settings}>
+//             {cards.map((card, index) => (
+//               <StockCard
+//                 stockId={index}
+//                 stockName={card[0]}
+//                 stockLevel={card[1]}
+//                 stockCount={card[2]}
+//                 stockPrice={card[3]}
+//                 limit={card[4]}
+//                 handleSelectedCountList={handleSelectedCountList}
+//                 selected={selectedCountList[index]}
+//               />
+//             ))}
+//           </Slider>
+//         </Wrapper>
+//       </div>
+//     </div>
+//   );
+// }

--- a/frontend/src/routes/stockcheck/component/SelectStockBar.tsx
+++ b/frontend/src/routes/stockcheck/component/SelectStockBar.tsx
@@ -1,70 +1,70 @@
-import Select from "react-select";
+// import Select from "react-select";
 
-interface SelectProps {
-  count: number;
-  selectedCount: number;
-  handleSelectedChage: (selected: number) => void;
-}
+// interface SelectProps {
+//   count: number;
+//   selectedCount: number;
+//   handleSelectedChage: (selected: number) => void;
+// }
 
-const customStyles = {
-  control: (provided: any) => ({
-    ...provided,
-    minHeight: "100%", // control 높이를 부모 div 높이에 맞춤
-    height: "100%", // 고정 높이
-  }),
-  valueContainer: (provided: any) => ({
-    ...provided,
-    height: "100%", // 내부 값 컨테이너 높이를 맞춤
-    padding: "0 8px",
-  }),
-  input: (provided: any) => ({
-    ...provided,
-    margin: "0px",
-  }),
-  indicatorsContainer: (provided: any) => ({
-    ...provided,
-    height: "100%", // 드롭다운 아이콘 컨테이너 높이 맞춤
-  }),
-  menu: (provided: any) => ({
-    ...provided,
-    maxHeight: "150px", // 옵션 목록의 최대 높이 설정
-  }),
-  menuList: (provided: any) => ({
-    ...provided,
-    maxHeight: "70px", // 옵션 목록의 최대 높이 설정
-    overflowY: "auto", // 스크롤 설정
-  }),
-};
+// const customStyles = {
+//   control: (provided: any) => ({
+//     ...provided,
+//     minHeight: "100%", // control 높이를 부모 div 높이에 맞춤
+//     height: "100%", // 고정 높이
+//   }),
+//   valueContainer: (provided: any) => ({
+//     ...provided,
+//     height: "100%", // 내부 값 컨테이너 높이를 맞춤
+//     padding: "0 8px",
+//   }),
+//   input: (provided: any) => ({
+//     ...provided,
+//     margin: "0px",
+//   }),
+//   indicatorsContainer: (provided: any) => ({
+//     ...provided,
+//     height: "100%", // 드롭다운 아이콘 컨테이너 높이 맞춤
+//   }),
+//   menu: (provided: any) => ({
+//     ...provided,
+//     maxHeight: "150px", // 옵션 목록의 최대 높이 설정
+//   }),
+//   menuList: (provided: any) => ({
+//     ...provided,
+//     maxHeight: "70px", // 옵션 목록의 최대 높이 설정
+//     overflowY: "auto", // 스크롤 설정
+//   }),
+// };
 
-export default function SelectStockBar({
-  count,
-  selectedCount,
-  handleSelectedChage,
-}: SelectProps) {
-  const range: { value: number; label: number }[] = [];
-  for (let i = 0; i <= count; i++) {
-    range.push({ value: i, label: i });
-  }
+// export default function SelectStockBar({
+//   count,
+//   selectedCount,
+//   handleSelectedChage,
+// }: SelectProps) {
+//   const range: { value: number; label: number }[] = [];
+//   for (let i = 0; i <= count; i++) {
+//     range.push({ value: i, label: i });
+//   }
 
-  console.log("선택한 주식량" + selectedCount);
-  const onChangeSelected = (selected: any) => {
-    console.log("onChangeSelected");
-    if (
-      selected &&
-      selected.value !== null &&
-      selected &&
-      selected.value !== undefined
-    ) {
-      handleSelectedChage(selected.value);
-    }
-  };
+//   console.log("선택한 주식량" + selectedCount);
+//   const onChangeSelected = (selected: any) => {
+//     console.log("onChangeSelected");
+//     if (
+//       selected &&
+//       selected.value !== null &&
+//       selected &&
+//       selected.value !== undefined
+//     ) {
+//       handleSelectedChage(selected.value);
+//     }
+//   };
 
-  return (
-    <Select
-      options={range}
-      value={range[selectedCount]}
-      onChange={onChangeSelected}
-      styles={customStyles}
-    />
-  );
-}
+//   return (
+//     <Select
+//       options={range}
+//       value={range[selectedCount]}
+//       onChange={onChangeSelected}
+//       styles={customStyles}
+//     />
+//   );
+// }

--- a/frontend/src/routes/stockcheck/component/SelectStockBar.tsx
+++ b/frontend/src/routes/stockcheck/component/SelectStockBar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Select from "react-select";
 
 interface SelectProps {
@@ -36,13 +36,35 @@ const customStyles = {
 };
 
 export default function SelectStockBar({ count }: SelectProps) {
+  const [selectCount, setSelectCount] = useState<number>(0);
+
   const range: { value: number; label: number }[] = [];
   for (let i = count; i >= 0; i--) {
     range.push({ value: i, label: i });
   }
 
-  const [selectCount, setSelectCount] = useState<number>(20);
+  const handleSelectedChange = (selected: any) => {
+    if (
+      selected &&
+      selected.value !== null &&
+      selected &&
+      selected.value !== undefined
+    ) {
+      setSelectCount(selected.value);
+    }
+  };
+
+  // selected 상태가 변경될 때마다 콘솔에 출력
+  useEffect(() => {
+    console.log(selectCount);
+  }, [selectCount]);
+
   return (
-    <Select options={range} defaultValue={range[0]} styles={customStyles} />
+    <Select
+      options={range}
+      defaultValue={range[0]}
+      onChange={handleSelectedChange}
+      styles={customStyles}
+    />
   );
 }

--- a/frontend/src/routes/stockcheck/component/SelectStockBar.tsx
+++ b/frontend/src/routes/stockcheck/component/SelectStockBar.tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect } from "react";
 import Select from "react-select";
 
 interface SelectProps {
   count: number;
+  handleSelectedChage: (selected: number) => void;
 }
 
 const customStyles = {
@@ -35,35 +35,31 @@ const customStyles = {
   }),
 };
 
-export default function SelectStockBar({ count }: SelectProps) {
-  const [selectCount, setSelectCount] = useState<number>(0);
-
+export default function SelectStockBar({
+  count,
+  handleSelectedChage,
+}: SelectProps) {
   const range: { value: number; label: number }[] = [];
-  for (let i = count; i >= 0; i--) {
+  for (let i = 0; i <= count; i++) {
     range.push({ value: i, label: i });
   }
 
-  const handleSelectedChange = (selected: any) => {
+  const onChangeSelected = (selected: any) => {
     if (
       selected &&
       selected.value !== null &&
       selected &&
       selected.value !== undefined
     ) {
-      setSelectCount(selected.value);
+      handleSelectedChage(selected.value);
     }
   };
-
-  // selected 상태가 변경될 때마다 콘솔에 출력
-  useEffect(() => {
-    console.log(selectCount);
-  }, [selectCount]);
 
   return (
     <Select
       options={range}
       defaultValue={range[0]}
-      onChange={handleSelectedChange}
+      onChange={onChangeSelected}
       styles={customStyles}
     />
   );

--- a/frontend/src/routes/stockcheck/component/SelectStockBar.tsx
+++ b/frontend/src/routes/stockcheck/component/SelectStockBar.tsx
@@ -1,10 +1,48 @@
 import { useState } from "react";
 import Select from "react-select";
 
-export default function SelectStockBar() {
-  const range = [{ value: 20 }, { value: 15 }, { value: 10 }, { value: 5 }];
+interface SelectProps {
+  count: number;
+}
+
+const customStyles = {
+  control: (provided: any) => ({
+    ...provided,
+    minHeight: "100%", // control 높이를 부모 div 높이에 맞춤
+    height: "100%", // 고정 높이
+  }),
+  valueContainer: (provided: any) => ({
+    ...provided,
+    height: "100%", // 내부 값 컨테이너 높이를 맞춤
+    padding: "0 8px",
+  }),
+  input: (provided: any) => ({
+    ...provided,
+    margin: "0px",
+  }),
+  indicatorsContainer: (provided: any) => ({
+    ...provided,
+    height: "100%", // 드롭다운 아이콘 컨테이너 높이 맞춤
+  }),
+  menu: (provided: any) => ({
+    ...provided,
+    maxHeight: "150px", // 옵션 목록의 최대 높이 설정
+  }),
+  menuList: (provided: any) => ({
+    ...provided,
+    maxHeight: "70px", // 옵션 목록의 최대 높이 설정
+    overflowY: "auto", // 스크롤 설정
+  }),
+};
+
+export default function SelectStockBar({ count }: SelectProps) {
+  const range: { value: number; label: number }[] = [];
+  for (let i = count; i >= 0; i--) {
+    range.push({ value: i, label: i });
+  }
+
   const [selectCount, setSelectCount] = useState<number>(20);
   return (
-    <Select options={range} onChange={setSelectCount} defaultValue={range[0]} />
+    <Select options={range} defaultValue={range[0]} styles={customStyles} />
   );
 }

--- a/frontend/src/routes/stockcheck/component/StockCard.tsx
+++ b/frontend/src/routes/stockcheck/component/StockCard.tsx
@@ -10,6 +10,7 @@ interface CardProps {
   stockCount: number;
   limit: number;
   handleSelectedCountList: (index: number, newCount: number) => void;
+  selected: number;
 
   //children: React.ReactNode;
 }
@@ -49,6 +50,7 @@ export default function StockCard({
   stockCount,
   limit,
   handleSelectedCountList,
+  selected,
 }: CardProps) {
   const [selectCount, setSelectCount] = useState<number>(0);
 
@@ -78,6 +80,7 @@ export default function StockCard({
           <div className="w-1/3">
             <SelectStockBar
               count={stockCount}
+              selectedCount={selected}
               handleSelectedChage={handleSelectedChange}
             />
           </div>

--- a/frontend/src/routes/stockcheck/component/StockCard.tsx
+++ b/frontend/src/routes/stockcheck/component/StockCard.tsx
@@ -1,13 +1,16 @@
-import { useEffect, useState } from "react";
+import { useState, useEffect } from "react";
 import styled from "styled-components";
 import SelectStockBar from "./SelectStockBar";
 
 interface CardProps {
+  stockId: number;
   stockName: string;
   stockLevel: string;
   stockPrice: number;
   stockCount: number;
   limit: number;
+  handleSelectedCountList: (index: number, newCount: number) => void;
+
   //children: React.ReactNode;
 }
 
@@ -39,19 +42,25 @@ const StyledCard = styled.div<ColorProps>`
 `;
 
 export default function StockCard({
+  stockId,
   stockName,
   stockLevel,
   stockPrice,
   stockCount,
   limit,
+  handleSelectedCountList,
 }: CardProps) {
-  //TODO: 로직 확인 필요
-  // useEffect(() => {
-  //   handleSelectedStock(selected);
-  // }, [selected]);
+  const [selectCount, setSelectCount] = useState<number>(0);
 
-  //TODO: selectedstockbar에서 변경 사항이 생기면 handleSelected를 사용해서 selected 업데이트
-  //selected가 업데이트가 완전히 끝나면 그때서야 handleSelectedStock 호출
+  //여기까지 선택주수 가져옴!
+  const handleSelectedChange = (selected: number) => {
+    setSelectCount(selected);
+  };
+
+  //여기서 선택주수 배열에 집어넣기
+  useEffect(() => {
+    handleSelectedCountList(stockId, selectCount);
+  }, [selectCount]);
 
   return (
     <StyledCard bgColor={getRandomColor()}>
@@ -61,20 +70,23 @@ export default function StockCard({
           <p>전일 종가 {stockPrice}원</p>
         </div>
         <div className="flex justify-between">
-          <p className="font-bold text-red-700	">{stockLevel}등급</p>{" "}
+          <p className="font-bold text-red-700	">{stockLevel}등급</p>
           <p>총 주수 {stockCount}주</p>
         </div>
         <div className="flex justify-end gap-3 items-center	">
           <div>주수 선택 </div>
           <div className="w-1/3">
-            <SelectStockBar count={stockCount} />
+            <SelectStockBar
+              count={stockCount}
+              handleSelectedChage={handleSelectedChange}
+            />
           </div>
         </div>
         <div className="flex flex-row-reverse">
           <p>총 가격 {stockCount * stockPrice}원</p>
         </div>
         <div className="flex flex-row-reverse">
-          <p>확보 가능한 최대 한도 {limit}원</p>
+          <p>확보 가능한 최대 한도 {limit * stockCount}원</p>
         </div>
       </div>
     </StyledCard>

--- a/frontend/src/routes/stockcheck/component/StockCard.tsx
+++ b/frontend/src/routes/stockcheck/component/StockCard.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import styled from "styled-components";
 import SelectStockBar from "./SelectStockBar";
 
@@ -44,6 +45,14 @@ export default function StockCard({
   stockCount,
   limit,
 }: CardProps) {
+  //TODO: 로직 확인 필요
+  // useEffect(() => {
+  //   handleSelectedStock(selected);
+  // }, [selected]);
+
+  //TODO: selectedstockbar에서 변경 사항이 생기면 handleSelected를 사용해서 selected 업데이트
+  //selected가 업데이트가 완전히 끝나면 그때서야 handleSelectedStock 호출
+
   return (
     <StyledCard bgColor={getRandomColor()}>
       <div className="flex flex-col gap-1.5">

--- a/frontend/src/routes/stockcheck/component/StockCard.tsx
+++ b/frontend/src/routes/stockcheck/component/StockCard.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import SelectStockBar from "./SelectStockBar";
 
 interface CardProps {
   stockName: string;
@@ -53,6 +54,12 @@ export default function StockCard({
         <div className="flex justify-between">
           <p className="font-bold text-red-700	">{stockLevel}등급</p>{" "}
           <p>총 주수 {stockCount}주</p>
+        </div>
+        <div className="flex justify-end gap-3 items-center	">
+          <div>주수 선택 </div>
+          <div className="w-1/3">
+            <SelectStockBar count={stockCount} />
+          </div>
         </div>
         <div className="flex flex-row-reverse">
           <p>총 가격 {stockCount * stockPrice}원</p>

--- a/frontend/src/routes/stockcheck/component/StockCard.tsx
+++ b/frontend/src/routes/stockcheck/component/StockCard.tsx
@@ -1,97 +1,97 @@
-import { useState, useEffect } from "react";
-import styled from "styled-components";
-import SelectStockBar from "./SelectStockBar";
+// import { useState, useEffect } from "react";
+// import styled from "styled-components";
+// import SelectStockBar from "./SelectStockBar";
 
-interface CardProps {
-  stockId: number;
-  stockName: string;
-  stockLevel: string;
-  stockPrice: number;
-  stockCount: number;
-  limit: number;
-  handleSelectedCountList: (index: number, newCount: number) => void;
-  selected: number;
+// interface CardProps {
+//   stockId: number;
+//   stockName: string;
+//   stockLevel: string;
+//   stockPrice: number;
+//   stockCount: number;
+//   limit: number;
+//   handleSelectedCountList: (index: number, newCount: number) => void;
+//   selected: number;
 
-  //children: React.ReactNode;
-}
+//   //children: React.ReactNode;
+// }
 
-interface ColorProps {
-  bgColor: string;
-}
+// interface ColorProps {
+//   bgColor: string;
+// }
 
-const colors = [
-  "#f7e8bc",
-  "#9abade",
-  "#f7bcea",
-  "#caf7bc",
-  "#b2de9a",
-  "#de9abd",
-];
-const getRandomColor = () => {
-  return colors[Math.floor(Math.random() * colors.length)];
-};
+// const colors = [
+//   "#f7e8bc",
+//   "#9abade",
+//   "#f7bcea",
+//   "#caf7bc",
+//   "#b2de9a",
+//   "#de9abd",
+// ];
+// const getRandomColor = () => {
+//   return colors[Math.floor(Math.random() * colors.length)];
+// };
 
-const StyledCard = styled.div<ColorProps>`
-  border-radius: 20px;
-  padding: 20px;
-  width: 316px;
-  height: 200px;
-  //background-color: #9abade;
-  background-color: ${(props) => props.bgColor}; /* 랜덤 색상을 설정 */
-  box-shadow: 1px 2px 3px rgba(0, 0, 0, 0.1);
-  margin: 0 10px; /* 카드 사이의 간격을 넓힘 */
-`;
+// const StyledCard = styled.div<ColorProps>`
+//   border-radius: 20px;
+//   padding: 20px;
+//   width: 316px;
+//   height: 200px;
+//   //background-color: #9abade;
+//   background-color: ${(props) => props.bgColor}; /* 랜덤 색상을 설정 */
+//   box-shadow: 1px 2px 3px rgba(0, 0, 0, 0.1);
+//   margin: 0 10px; /* 카드 사이의 간격을 넓힘 */
+// `;
 
-export default function StockCard({
-  stockId,
-  stockName,
-  stockLevel,
-  stockPrice,
-  stockCount,
-  limit,
-  handleSelectedCountList,
-  selected,
-}: CardProps) {
-  const [selectCount, setSelectCount] = useState<number>(0);
+// export default function StockCard({
+//   stockId,
+//   stockName,
+//   stockLevel,
+//   stockPrice,
+//   stockCount,
+//   limit,
+//   handleSelectedCountList,
+//   selected,
+// }: CardProps) {
+//   const [selectCount, setSelectCount] = useState<number>(0);
 
-  //여기까지 선택주수 가져옴!
-  const handleSelectedChange = (selected: number) => {
-    setSelectCount(selected);
-  };
+//   //여기까지 선택주수 가져옴!
+//   const handleSelectedChange = (selected: number) => {
+//     setSelectCount(selected);
+//   };
 
-  //여기서 선택주수 배열에 집어넣기
-  useEffect(() => {
-    handleSelectedCountList(stockId, selectCount);
-  }, [selectCount]);
+//   //여기서 선택주수 배열에 집어넣기
+//   useEffect(() => {
+//     handleSelectedCountList(stockId, selectCount);
+//   }, [selectCount]);
 
-  return (
-    <StyledCard bgColor={getRandomColor()}>
-      <div className="flex flex-col gap-1.5">
-        <div className="flex justify-between">
-          <p className="font-bold">{stockName}</p>{" "}
-          <p>전일 종가 {stockPrice}원</p>
-        </div>
-        <div className="flex justify-between">
-          <p className="font-bold text-red-700	">{stockLevel}등급</p>
-          <p>총 주수 {stockCount}주</p>
-        </div>
-        <div className="flex justify-end gap-3 items-center	">
-          <div>주수 선택 </div>
-          <div className="w-1/3">
-            <SelectStockBar
-              count={stockCount}
-              selectedCount={selected}
-              handleSelectedChage={handleSelectedChange}
-            />
-          </div>
-        </div>
-        <div className="flex flex-row-reverse">
-          <p>총 가격 {stockCount * stockPrice}원</p>
-        </div>
-        <div className="flex flex-row-reverse">
-          <p>확보 가능한 최대 한도 {limit * stockCount}원</p>
-        </div>
-      </div>
-    </StyledCard>
-  );
-}
+//   return (
+//     <StyledCard bgColor={getRandomColor()}>
+//       <div className="flex flex-col gap-1.5">
+//         <div className="flex justify-between">
+//           <p className="font-bold">{stockName}</p>{" "}
+//           <p>전일 종가 {stockPrice}원</p>
+//         </div>
+//         <div className="flex justify-between">
+//           <p className="font-bold text-red-700	">{stockLevel}등급</p>
+//           <p>총 주수 {stockCount}주</p>
+//         </div>
+//         <div className="flex justify-end gap-3 items-center	">
+//           <div>주수 선택 </div>
+//           <div className="w-1/3">
+//             <SelectStockBar
+//               count={stockCount}
+//               selectedCount={selected}
+//               handleSelectedChage={handleSelectedChange}
+//             />
+//           </div>
+//         </div>
+//         <div className="flex flex-row-reverse">
+//           <p>총 가격 {stockCount * stockPrice}원</p>
+//         </div>
+//         <div className="flex flex-row-reverse">
+//           <p>확보 가능한 최대 한도 {limit * stockCount}원</p>
+//         </div>
+//       </div>
+//     </StyledCard>
+//   );
+// }

--- a/frontend/src/routes/stockcheck/component/StockEditModal.tsx
+++ b/frontend/src/routes/stockcheck/component/StockEditModal.tsx
@@ -1,66 +1,66 @@
-import { useState } from "react";
-import BasicModal from "../../../components/modal/BasicModal";
-import XButton from "../../../components/button/XButton";
-import ChangeStockBar from "../../selectedstock/component/ChangeStockBar";
-import BasicButton from "../../../components/button/BasicButton";
+// import { useState } from "react";
+// import BasicModal from "../../../components/modal/BasicModal";
+// import XButton from "../../../components/button/XButton";
+// import ChangeStockBar from "../../selectedstock/component/ChangeStockBar";
+// import BasicButton from "../../../components/button/BasicButton";
 
-interface ModalProps {
-  index: number;
-  value: number;
-  max: number;
-  isModalOpen: boolean;
-  onCloseModal: () => void;
-  updateStockList: (index: number, value: number) => void;
-}
+// interface ModalProps {
+//   index: number;
+//   value: number;
+//   max: number;
+//   isModalOpen: boolean;
+//   onCloseModal: () => void;
+//   updateStockList: (index: number, value: number) => void;
+// }
 
-export default function StockEditModal({
-  index,
-  value,
-  max,
-  isModalOpen,
-  onCloseModal,
-  updateStockList,
-}: ModalProps) {
-  const [tempSelected, setTempSelected] = useState<[number, number]>([
-    index,
-    value,
-  ]);
+// export default function StockEditModal({
+//   index,
+//   value,
+//   max,
+//   isModalOpen,
+//   onCloseModal,
+//   updateStockList,
+// }: ModalProps) {
+//   const [tempSelected, setTempSelected] = useState<[number, number]>([
+//     index,
+//     value,
+//   ]);
 
-  const handleTempSelected = (index: number, cValue: number) => {
-    if (cValue !== null) setTempSelected([index, cValue]);
-  };
+//   const handleTempSelected = (index: number, cValue: number) => {
+//     if (cValue !== null) setTempSelected([index, cValue]);
+//   };
 
-  const handleDeleteButton = () => {
-    updateStockList(index, 0);
-    onCloseModal();
-  };
+//   const handleDeleteButton = () => {
+//     updateStockList(index, 0);
+//     onCloseModal();
+//   };
 
-  const handleFinishButton = () => {
-    updateStockList(tempSelected[0], tempSelected[1]);
-    onCloseModal();
-  };
+//   const handleFinishButton = () => {
+//     updateStockList(tempSelected[0], tempSelected[1]);
+//     onCloseModal();
+//   };
 
-  return (
-    <BasicModal isOpen={isModalOpen} onRequestClose={onCloseModal}>
-      <div className="flex flex-row-reverse">
-        <span onClick={onCloseModal}>
-          <XButton />
-        </span>
-      </div>
-      <h2>선택한 주수: {value}</h2>
-      <h2>
-        수정할 주수:
-        <p className="w-1/3">
-          <ChangeStockBar
-            index={index}
-            count={max}
-            selected={value}
-            handleSelectedChage={handleTempSelected}
-          />
-        </p>
-      </h2>
-      <BasicButton onClick={handleDeleteButton}>삭제</BasicButton>
-      <BasicButton onClick={handleFinishButton}>완료</BasicButton>
-    </BasicModal>
-  );
-}
+//   return (
+//     <BasicModal isOpen={isModalOpen} onRequestClose={onCloseModal}>
+//       <div className="flex flex-row-reverse">
+//         <span onClick={onCloseModal}>
+//           <XButton />
+//         </span>
+//       </div>
+//       <h2>선택한 주수: {value}</h2>
+//       <h2>
+//         수정할 주수:
+//         <p className="w-1/3">
+//           <ChangeStockBar
+//             index={index}
+//             count={max}
+//             selected={value}
+//             handleSelectedChage={handleTempSelected}
+//           />
+//         </p>
+//       </h2>
+//       <BasicButton onClick={handleDeleteButton}>삭제</BasicButton>
+//       <BasicButton onClick={handleFinishButton}>완료</BasicButton>
+//     </BasicModal>
+//   );
+// }

--- a/frontend/src/routes/stockcheck/component/StockEditModal.tsx
+++ b/frontend/src/routes/stockcheck/component/StockEditModal.tsx
@@ -1,10 +1,12 @@
+import { useState } from "react";
 import BasicModal from "../../../components/modal/BasicModal";
 import XButton from "../../../components/button/XButton";
 import ChangeStockBar from "../../selectedstock/component/ChangeStockBar";
+import BasicButton from "../../../components/button/BasicButton";
 
 interface ModalProps {
   index: number;
-  value: number | null;
+  value: number;
   max: number;
   isModalOpen: boolean;
   onCloseModal: () => void;
@@ -19,6 +21,25 @@ export default function StockEditModal({
   onCloseModal,
   updateStockList,
 }: ModalProps) {
+  const [tempSelected, setTempSelected] = useState<[number, number]>([
+    index,
+    value,
+  ]);
+
+  const handleTempSelected = (index: number, cValue: number) => {
+    if (cValue !== null) setTempSelected([index, cValue]);
+  };
+
+  const handleDeleteButton = () => {
+    updateStockList(index, 0);
+    onCloseModal();
+  };
+
+  const handleFinishButton = () => {
+    updateStockList(tempSelected[0], tempSelected[1]);
+    onCloseModal();
+  };
+
   return (
     <BasicModal isOpen={isModalOpen} onRequestClose={onCloseModal}>
       <div className="flex flex-row-reverse">
@@ -26,18 +47,20 @@ export default function StockEditModal({
           <XButton />
         </span>
       </div>
-      <h2>선택한 값</h2>
-      <p>{value}</p>
-      <h2>최대 값</h2>
-      <p>{max}</p>
-      <div className="w-1/3">
-        <ChangeStockBar
-          index={index}
-          count={max}
-          selected={value}
-          handleSelectedChage={updateStockList}
-        />
-      </div>
+      <h2>선택한 주수: {value}</h2>
+      <h2>
+        수정할 주수:
+        <p className="w-1/3">
+          <ChangeStockBar
+            index={index}
+            count={max}
+            selected={value}
+            handleSelectedChage={handleTempSelected}
+          />
+        </p>
+      </h2>
+      <BasicButton onClick={handleDeleteButton}>삭제</BasicButton>
+      <BasicButton onClick={handleFinishButton}>완료</BasicButton>
     </BasicModal>
   );
 }

--- a/frontend/src/routes/stockcheck/component/StockEditModal.tsx
+++ b/frontend/src/routes/stockcheck/component/StockEditModal.tsx
@@ -1,0 +1,43 @@
+import BasicModal from "../../../components/modal/BasicModal";
+import XButton from "../../../components/button/XButton";
+import ChangeStockBar from "../../selectedstock/component/ChangeStockBar";
+
+interface ModalProps {
+  index: number;
+  value: number | null;
+  max: number;
+  isModalOpen: boolean;
+  onCloseModal: () => void;
+  updateStockList: (index: number, value: number) => void;
+}
+
+export default function StockEditModal({
+  index,
+  value,
+  max,
+  isModalOpen,
+  onCloseModal,
+  updateStockList,
+}: ModalProps) {
+  return (
+    <BasicModal isOpen={isModalOpen} onRequestClose={onCloseModal}>
+      <div className="flex flex-row-reverse">
+        <span onClick={onCloseModal}>
+          <XButton />
+        </span>
+      </div>
+      <h2>선택한 값</h2>
+      <p>{value}</p>
+      <h2>최대 값</h2>
+      <p>{max}</p>
+      <div className="w-1/3">
+        <ChangeStockBar
+          index={index}
+          count={max}
+          selected={value}
+          handleSelectedChage={updateStockList}
+        />
+      </div>
+    </BasicModal>
+  );
+}

--- a/frontend/src/routes/stockcheck/component/StockLevelModal.tsx
+++ b/frontend/src/routes/stockcheck/component/StockLevelModal.tsx
@@ -1,24 +1,24 @@
-import BasicModal from "../../../components/modal/BasicModal";
-import XButton from "../../../components/button/XButton";
+// import BasicModal from "../../../components/modal/BasicModal";
+// import XButton from "../../../components/button/XButton";
 
-interface ModalProps {
-  isModalOpen: boolean;
-  handleCloseModal: () => void;
-}
+// interface ModalProps {
+//   isModalOpen: boolean;
+//   handleCloseModal: () => void;
+// }
 
-export default function StockLevelModal({
-  isModalOpen,
-  handleCloseModal,
-}: ModalProps) {
-  return (
-    <BasicModal isOpen={isModalOpen} onRequestClose={handleCloseModal}>
-      <div className="flex flex-row-reverse">
-        <span onClick={handleCloseModal}>
-          <XButton />
-        </span>
-      </div>
-      <h2>주식 등급 안내</h2>
-      <p>A등급 ~</p>
-    </BasicModal>
-  );
-}
+// export default function StockLevelModal({
+//   isModalOpen,
+//   handleCloseModal,
+// }: ModalProps) {
+//   return (
+//     <BasicModal isOpen={isModalOpen} onRequestClose={handleCloseModal}>
+//       <div className="flex flex-row-reverse">
+//         <span onClick={handleCloseModal}>
+//           <XButton />
+//         </span>
+//       </div>
+//       <h2>주식 등급 안내</h2>
+//       <p>A등급 ~</p>
+//     </BasicModal>
+//   );
+// }


### PR DESCRIPTION
## 🔖 PR 타입
- [x] 기능 추가
- [x] 기능 수정
- [x] 리팩토링

## 🌿 반영 브랜치
ex) feat-stockselect -> main

## ⚒️ 구현 사항
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 고객이 결제 서비스 이용 약관에 동의했을 시에, 고객이 보유한 주식을 증권사별로 카드 형식으로 보여주는 화면을 구현했습니다. 
   - 고객이 해당 카드 내 셀렉트바를 통해 주수를 선택할 수 있는 기능 개발
   - 선택 주수에 따라 한도를 계산해주는 기능 개발
- 고객이 본인이 담보로 선택한 주식을 한 번에 확인할 수 있는 화면을 구현했습니다. 
  - 주식 종목을 클릭했을 시 모달 창이 뜨고 해당 모달 창을 통해 담보로 잡은 주식을 삭제하거나 주수를 수정할 수 있는 기능 개발
 - 보유 주식 페이지, 담보 주식 페이지 구현 후 프롭스 전달 과정이 효율적이지 못한 것 같아 코드를 리팩토링 했습니다. 
   - 하나의 컴포넌트 안에 조건에 따라 보유 주식 컴포넌트, 담보 주식 컴포넌트를 보여주는 것으로 코드 수정 

## ✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
<img width="339" alt="보유주식" src="https://github.com/user-attachments/assets/a0c2353f-95f7-4323-8e17-70f3ab61ac09">
<img width="337" alt="담보주식" src="https://github.com/user-attachments/assets/2204e875-4767-4b31-9dde-0bd636e643e1">
<img width="339" alt="담보모달" src="https://github.com/user-attachments/assets/0d9cdbf2-517c-4a68-b0b8-b5f16926be51">

