### PR TITLE
feat: 한도 설정 페이지 구현

### DIFF
--- a/frontend/src/routes/settinglimit/SettingLimitPage.tsx
+++ b/frontend/src/routes/settinglimit/SettingLimitPage.tsx
@@ -1,48 +1,101 @@
-import { useLocation } from "react-router-dom";
+import React, { useEffect, useState } from "react";
+//import { useLocation } from "react-router-dom";
 import PaddingDiv from "../../components/settingdiv/PaddingDiv";
 import BoldTitle from "../../components/text/BoldTitle";
+import NormalTitle from "../../components/text/NormalTitle";
+import BackgroundFrame from "../../components/backgroundframe/BackgroundFrame";
+import ButtonBar from "../../components/button/ButtonBar";
 
 export default function SettingLimitPage() {
-  const location = useLocation();
+  //TODO: api GET요청으로 받아온 데이터
+  //현재한도, 최대한도, 담보
+  const data: [number, number, number] = [50000000, 50000000, 10000000000];
 
-  //TODO: 아마 로그인시 유저 정보를 id와 이름을 보내줄거니까 배열에 저장해두고 사용
-  const userInfo: [number, string] = [111, "정윤현"];
+  const [limit, setLimit] = useState<number>(data[0]);
+  const [mortgageRate, setMortgageRate] = useState<number>(data[2] / limit);
+  const [errLimit, setErrLimit] = useState<boolean>(false);
 
-  const { selectedStock } = location.state as {
-    selectedStock: [
-      string, //0: 증권사 코드
-      string, //1: 증권사명
-      string, //2: 종목명
-      string, //3: 등급
-      number, //4: 전일종가
-      number, //5: 선택한 주수
-      number, //6: 전체 주수
-      number, //7: 한도
-      string //8: 계좌번호
-    ][];
+  const [inputValue, setInputValue] = useState<string>("");
+
+  const validateLimit = () => {
+    if (limit > data[1] || limit < 0 || mortgageRate < 140) {
+      console.log("에러 발생 한도는 " + mortgageRate);
+      setErrLimit(true);
+    } else {
+      console.log("에러 해제 ");
+      setErrLimit(false);
+    }
   };
 
-  const { priorityStock } = location.state as {
-    priorityStock: [
-      number, //0: id
-      string, //1: 증권사 코드
-      string, //2: 증권사명
-      string, //3: 종목명
-      string, //4: 등급
-      number, //5: 전일종가
-      number, //6: 우선순위로 고른 주수
-      number, //7: 담보로 잡은 전체 주수
-      number, //8: 한도
-      string //9: 계좌 번호
-    ][];
+  const updateLimit = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const v = event.target.value;
+    const vToNum = Number(v);
+
+    console.log("값 들어옴 " + vToNum);
+
+    if (!isNaN(vToNum) && v !== " ") {
+      setInputValue(v);
+      setLimit(vToNum);
+    } else {
+      setErrLimit(true);
+    }
   };
 
-  console.log("prioritystock은 ");
-  console.log(priorityStock);
+  useEffect(() => {
+    validateLimit();
+  }, [limit, mortgageRate]);
+
+  useEffect(() => {
+    setMortgageRate(data[2] / limit);
+  }, [limit]);
 
   return (
     <PaddingDiv>
       <BoldTitle>한도를 설정해보세요.</BoldTitle>
+      <div>
+        <NormalTitle>현재 고객님의 한도 현황입니다.</NormalTitle>
+        <BackgroundFrame color="blue">
+          <BoldTitle>현재 한도: {limit}</BoldTitle>
+          <BoldTitle>최대 한도: {data[1]}</BoldTitle>
+          <NormalTitle>담보: {data[2]}</NormalTitle>
+          <NormalTitle>담보 유지 비율: {mortgageRate}%</NormalTitle>
+        </BackgroundFrame>
+        <div className="text-sm	text-gray-400">
+          최대 한도를 늘리려면 담보를 더 잡아야 합니다.
+        </div>
+      </div>
+      <div>
+        <NormalTitle>원하시는 한도를 입력해주세요.</NormalTitle>
+        <BackgroundFrame color="blue">
+          <div>
+            <label className="block">
+              <span>최대 {data[1]}원 설정 가능합니다.</span>
+              <input
+                type="text"
+                pattern="[0-9]*"
+                name="limit"
+                value={inputValue}
+                onChange={updateLimit}
+                className="mt-1 px-3 py-2 bg-white border shadow-sm border-slate-300 placeholder-slate-400 focus:outline-none focus:border-sky-500 focus:ring-sky-500 block w-full rounded-md sm:text-sm focus:ring-1"
+              />
+              {errLimit && (
+                <p className="mt-2 text-sm text-red-600">
+                  {
+                    "최대 한도 이하의 담보 유지 비율 140%이 되는 한도로 설정해주세요."
+                  }
+                </p>
+              )}
+            </label>
+          </div>
+        </BackgroundFrame>
+      </div>
+      <ButtonBar
+        beforetext="이전"
+        beforeurl="/priority"
+        nexttext="완료"
+        nextdisabled={errLimit}
+        nexturl="/"
+      />
     </PaddingDiv>
   );
 }


### PR DESCRIPTION
## 🔖 PR 타입
- [x] 기능 추가

## 🌿 반영 브랜치
feat-setlimit -> main

## ⚒️ 구현 사항
- 한도 설정 페이지 구현했습니다.
- 고객에게 현재 한도, 최대 한도, 담보금액, 담보금액을 보여줍니다. 
- input 창을 통해 고객에게 한도 금액을 입력 받는 기능을 구현했습니다.
- 최대 한도를 넘는 금액을 입력하거나, 담보 유지 비율이 140% 낮아지는 경우 한도를 설정하지 못하게 했습니다. 

## ✅ 테스트 결과
<img width="340" alt="한도1" src="https://github.com/user-attachments/assets/76e437e3-d1f4-42d0-a32d-390b4d48dc02">
<img width="342" alt="한도2" src="https://github.com/user-attachments/assets/f0f1b83a-50a9-4446-a69c-7a755f1f3936">

