### PR TITLE
feat: 결제 계좌 선택 페이지 구현

### DIFF
--- a/frontend/src/main-router.tsx
+++ b/frontend/src/main-router.tsx
@@ -12,6 +12,8 @@ import ServiceAgreePage from "./routes/agree/ServiceAgreePage";
 import PriorityPage from "./routes/priority/PriorityPage";
 import SettingLimitPage from "./routes/settinglimit/SettingLimitPage";
 import StockPage from "./routes/stock/StockPage";
+import SettingAccountPage from "./routes/account/SettingAccountPage";
+import SettingDatePage from "./routes/paymentdate/SettingDatePage";
 
 const routers = [
   {
@@ -98,6 +100,14 @@ const routers = [
   {
     path: "/limit",
     element: <SettingLimitPage />,
+  },
+  {
+    path: "/account",
+    element: <SettingAccountPage />,
+  },
+  {
+    path: "/paymentdate",
+    element: <SettingDatePage />,
   },
 ];
 

--- a/frontend/src/routes/account/SettingAccountPage.tsx
+++ b/frontend/src/routes/account/SettingAccountPage.tsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+import PaddingDiv from "../../components/settingdiv/PaddingDiv";
+import BoldTitle from "../../components/text/BoldTitle";
+import BackgroundFrame from "../../components/backgroundframe/BackgroundFrame";
+import ButtonBar from "../../components/button/ButtonBar";
+
+export default function SettingAccountPage() {
+  //TODO: api 요청으로 은행 목록 가져오기
+  const data: [string, string][] = [
+    ["신한은행", "0000-0000-0000"],
+    ["국민은행", "1111-1111-1111"],
+    ["하나은행", "2222-2222-2222"],
+    ["신한은행", "3333-3333-3333"],
+  ];
+  const [account, setAccount] = useState<[string, string]>();
+  const [check, setCheck] = useState<boolean>(false);
+
+  const handleAccount = (index: number) => {
+    setAccount([...data[index]]);
+    setCheck(true);
+  };
+
+  return (
+    <PaddingDiv>
+      <BoldTitle>결제 계좌를 선택해주세요.</BoldTitle>
+      <div className="flex flex-col gap-3">
+        {data.map((row, index) => (
+          <BackgroundFrame color="blue">
+            <div className="flex gap-10" onClick={() => handleAccount(index)}>
+              <span>{row[0]}</span>
+              <span>{row[1]}</span>
+            </div>
+          </BackgroundFrame>
+        ))}
+      </div>
+      <div>
+        <BoldTitle>선택한 계좌</BoldTitle>
+        <BackgroundFrame color="blue">
+          {account !== undefined ? (
+            <div className="flex gap-10">
+              <span>{account[0]}</span>
+              <span>{account[1]}</span>
+            </div>
+          ) : (
+            <div>계좌를 연결해주세요.</div>
+          )}
+        </BackgroundFrame>
+      </div>
+
+      <ButtonBar
+        beforetext="이전"
+        beforeurl="/limit"
+        nexttext="완료"
+        nextdisabled={!check}
+        nexturl="/paymentdate"
+      />
+    </PaddingDiv>
+  );
+}

--- a/frontend/src/routes/paymentdate/SettingDatePage.tsx
+++ b/frontend/src/routes/paymentdate/SettingDatePage.tsx
@@ -1,0 +1,16 @@
+import BackgroundFrame from "../../components/backgroundframe/BackgroundFrame";
+import PaddingDiv from "../../components/settingdiv/PaddingDiv";
+import BoldTitle from "../../components/text/BoldTitle";
+
+export default function SettingDatePage() {
+  return (
+    <PaddingDiv>
+      <div>
+        <BoldTitle>결제일 선택</BoldTitle>
+        <BackgroundFrame color="blue">
+          <div>달력</div>
+        </BackgroundFrame>
+      </div>
+    </PaddingDiv>
+  );
+}

--- a/frontend/src/routes/settinglimit/SettingLimitPage.tsx
+++ b/frontend/src/routes/settinglimit/SettingLimitPage.tsx
@@ -13,7 +13,7 @@ export default function SettingLimitPage() {
 
   const [limit, setLimit] = useState<number>(data[0]);
   const [mortgageRate, setMortgageRate] = useState<number>(data[2] / limit);
-  const [errLimit, setErrLimit] = useState<boolean>(false);
+  const [errLimit, setErrLimit] = useState<boolean>();
 
   const [inputValue, setInputValue] = useState<string>("");
 
@@ -55,9 +55,9 @@ export default function SettingLimitPage() {
       <div>
         <NormalTitle>현재 고객님의 한도 현황입니다.</NormalTitle>
         <BackgroundFrame color="blue">
-          <BoldTitle>현재 한도: {limit}</BoldTitle>
-          <BoldTitle>최대 한도: {data[1]}</BoldTitle>
-          <NormalTitle>담보: {data[2]}</NormalTitle>
+          <BoldTitle>현재 한도: {limit} 원</BoldTitle>
+          <BoldTitle>최대 한도: {data[1]} 원</BoldTitle>
+          <NormalTitle>담보: {data[2]} 원</NormalTitle>
           <NormalTitle>담보 유지 비율: {mortgageRate}%</NormalTitle>
         </BackgroundFrame>
         <div className="text-sm	text-gray-400">
@@ -76,6 +76,7 @@ export default function SettingLimitPage() {
                 name="limit"
                 value={inputValue}
                 onChange={updateLimit}
+                placeholder={data[1].toString()}
                 className="mt-1 px-3 py-2 bg-white border shadow-sm border-slate-300 placeholder-slate-400 focus:outline-none focus:border-sky-500 focus:ring-sky-500 block w-full rounded-md sm:text-sm focus:ring-1"
               />
               {errLimit && (
@@ -94,7 +95,7 @@ export default function SettingLimitPage() {
         beforeurl="/priority"
         nexttext="완료"
         nextdisabled={errLimit}
-        nexturl="/"
+        nexturl="/account"
       />
     </PaddingDiv>
   );


### PR DESCRIPTION
## 🔖 PR 타입
- [x] 기능 추가

## 🌿 반영 브랜치
feat-setaccount -> main

## ⚒️ 구현 사항
- 고객이 보유하고 있는 계좌를 보여줌.
- 고객이 계좌를 선택했을 시, 선택한 계좌를 보여줌.
- 계좌를 선택 안하면, 완료 버튼 비활성화함.

## ✅ 테스트 결과
<img width="341" alt="계좌1" src="https://github.com/user-attachments/assets/fb906f96-3225-4637-8a6b-2f828e32d54f">
<img width="339" alt="계좌2" src="https://github.com/user-attachments/assets/16c06b93-3a57-44b0-ae6b-bb710d632083">

