### PR TITLE
Feat: 결제일 선택 페이지 구현

### DIFF
--- a/frontend/src/main-router.tsx
+++ b/frontend/src/main-router.tsx
@@ -14,6 +14,7 @@ import SettingLimitPage from "./routes/settinglimit/SettingLimitPage";
 import StockPage from "./routes/stock/StockPage";
 import SettingAccountPage from "./routes/account/SettingAccountPage";
 import SettingDatePage from "./routes/paymentdate/SettingDatePage";
+import ConfirmPage from "./routes/confirm/ConfirmPage";
 
 const routers = [
   {
@@ -85,14 +86,6 @@ const routers = [
     path: "/stock",
     element: <StockPage />,
   },
-  // {
-  //   path: "/stockcheck",
-  //   element: <StockCheckPage />,
-  // },
-  // {
-  //   path: "/selectedstock",
-  //   element: <SelectedStockPage />,
-  // },
   {
     path: "/priority",
     element: <PriorityPage />,
@@ -108,6 +101,10 @@ const routers = [
   {
     path: "/paymentdate",
     element: <SettingDatePage />,
+  },
+  {
+    path: "/confirm",
+    element: <ConfirmPage />,
   },
 ];
 

--- a/frontend/src/routes/confirm/ConfirmPage.tsx
+++ b/frontend/src/routes/confirm/ConfirmPage.tsx
@@ -1,0 +1,10 @@
+import PaddingDiv from "../../components/settingdiv/PaddingDiv";
+import BoldTitle from "../../components/text/BoldTitle";
+
+export default function ConfirmPage() {
+  return (
+    <PaddingDiv>
+      <BoldTitle>최종 확인 페이지 입니다.</BoldTitle>
+    </PaddingDiv>
+  );
+}

--- a/frontend/src/routes/paymentdate/SettingDatePage.tsx
+++ b/frontend/src/routes/paymentdate/SettingDatePage.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import BackgroundFrame from "../../components/backgroundframe/BackgroundFrame";
 import PaddingDiv from "../../components/settingdiv/PaddingDiv";
 import BoldTitle from "../../components/text/BoldTitle";
 import NormalTitle from "../../components/text/NormalTitle";
@@ -58,7 +57,7 @@ export default function SettingDatePage() {
         beforetext="이전"
         beforeurl="/account"
         nexttext="완료"
-        nexturl="/"
+        nexturl="/confirm"
         nextdisabled={!isClicked}
       />
     </PaddingDiv>

--- a/frontend/src/routes/paymentdate/SettingDatePage.tsx
+++ b/frontend/src/routes/paymentdate/SettingDatePage.tsx
@@ -1,16 +1,66 @@
+import { useState } from "react";
 import BackgroundFrame from "../../components/backgroundframe/BackgroundFrame";
 import PaddingDiv from "../../components/settingdiv/PaddingDiv";
 import BoldTitle from "../../components/text/BoldTitle";
+import NormalTitle from "../../components/text/NormalTitle";
+import ButtonBar from "../../components/button/ButtonBar";
 
 export default function SettingDatePage() {
+  const date: number[] = [
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+    22, 23, 24, 25, 26, 27,
+  ];
+  const [paymentDate, setPaymentDate] = useState<number>();
+
+  const [isClicked, setIsClicked] = useState<boolean>(false);
+
+  const handleClick = (date: number) => {
+    setIsClicked(true);
+    setPaymentDate(date);
+  };
+
   return (
     <PaddingDiv>
-      <div>
-        <BoldTitle>결제일 선택</BoldTitle>
-        <BackgroundFrame color="blue">
-          <div>달력</div>
-        </BackgroundFrame>
+      <BoldTitle>결제일을 선택해주세요.</BoldTitle>
+      <div className="grid grid-cols-4 gap-4">
+        {date.map((item, index) => (
+          <button
+            key={index}
+            className="text-center rounded-lg"
+            style={{
+              backgroundColor: `${
+                item === paymentDate ? "#9abade" : "transparent"
+              }`,
+              border: "1px solid #9abade",
+              padding: "10px 20px",
+              cursor: "pointer",
+              borderRadius: "4px",
+              fontSize: "16px",
+            }}
+            onClick={() => handleClick(item)}
+          >
+            {item}
+          </button>
+        ))}
       </div>
+      <div>
+        {isClicked ? (
+          <NormalTitle>
+            선택된 결제일은{" "}
+            <span className="font-bold text-blue-600">{paymentDate}일</span>{" "}
+            입니다.{" "}
+          </NormalTitle>
+        ) : (
+          <div></div>
+        )}
+      </div>
+      <ButtonBar
+        beforetext="이전"
+        beforeurl="/account"
+        nexttext="완료"
+        nexturl="/"
+        nextdisabled={!isClicked}
+      />
     </PaddingDiv>
   );
 }


### PR DESCRIPTION
## 🔖 PR 타입
- [x] 기능 추가

## 🌿 반영 브랜치
feat-setpaymentdate -> main

## ⚒️ 구현 사항
- 결제일 선택 페이지 구현했습니다.
- 결제일을 선택 안 했을 시, 다음 버튼 비활성화
- 선택한 결제일 버튼 배경색 변경

## ✅ 테스트 결과
<img width="339" alt="결제일1" src="https://github.com/user-attachments/assets/90623e59-7855-46cd-8be3-242748ff9fdc">
<img width="342" alt="결제일2" src="https://github.com/user-attachments/assets/d201d24f-304b-44b4-83b2-9932ee22fdbf">

