### PR TITLE
feat: 간편 비밀번호 설정 페이지 구현

### DIFF
--- a/frontend/src/main-router.tsx
+++ b/frontend/src/main-router.tsx
@@ -15,6 +15,7 @@ import StockPage from "./routes/stock/StockPage";
 import SettingAccountPage from "./routes/account/SettingAccountPage";
 import SettingDatePage from "./routes/paymentdate/SettingDatePage";
 import ConfirmPage from "./routes/confirm/ConfirmPage";
+import SimplePage from "./routes/simplepsw/SimplePage";
 
 const routers = [
   {
@@ -105,6 +106,10 @@ const routers = [
   {
     path: "/confirm",
     element: <ConfirmPage />,
+  },
+  {
+    path: "/simple",
+    element: <SimplePage />,
   },
 ];
 

--- a/frontend/src/routes/confirm/ConfirmPage.tsx
+++ b/frontend/src/routes/confirm/ConfirmPage.tsx
@@ -271,7 +271,7 @@ export default function ConfirmPage() {
         beforetext="이전"
         nexttext="다음"
         beforeurl="/paymentdate"
-        nexturl="/"
+        nexturl="/simple"
       ></ButtonBar>
     </PaddingDiv>
   );

--- a/frontend/src/routes/simplepsw/SimplePage.tsx
+++ b/frontend/src/routes/simplepsw/SimplePage.tsx
@@ -1,10 +1,123 @@
+import { useEffect, useState } from "react";
 import PaddingDiv from "../../components/settingdiv/PaddingDiv";
 import NormalTitle from "../../components/text/NormalTitle";
+import ButtonBar from "../../components/button/ButtonBar";
 
 export default function SimplePage() {
+  const [password, setPassword] = useState<string>();
+  const [checkPsw, setCheckPsw] = useState<string>();
+  const [errPsw, setErrPsw] = useState<boolean>();
+  const [errChkPsw, setErrChkPsw] = useState<boolean>();
+  const [inputValue, setInputValue] = useState<string>("");
+  const [inputChkValue, setInputChkValue] = useState<string>("");
+
+  const validatePsw = () => {
+    console.log("비번 " + password);
+    if (password !== undefined && password.length !== 6) {
+      setErrPsw(true);
+    } else {
+      setErrPsw(false);
+    }
+  };
+
+  const updatePsw = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    const vNum = Number(value);
+
+    if (!isNaN(vNum) && value !== " ") {
+      setPassword(value);
+      setInputValue(value);
+    } else {
+      setErrPsw(true);
+    }
+  };
+
+  useEffect(() => {
+    validatePsw();
+  }, [password, checkPsw]);
+
+  const validateChkPsw = () => {
+    console.log("chk비번 " + checkPsw);
+    if (password !== checkPsw) {
+      setErrChkPsw(true);
+    } else {
+      setErrChkPsw(false);
+    }
+  };
+
+  const updateChkPsw = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    const vNum = Number(value);
+
+    if (!isNaN(vNum) && value !== " ") {
+      setCheckPsw(value);
+      setInputChkValue(value);
+    } else {
+      setErrChkPsw(true);
+    }
+  };
+
+  useEffect(() => {
+    if (checkPsw !== undefined) validateChkPsw();
+  }, [checkPsw, password]);
+
   return (
     <PaddingDiv>
-      <NormalTitle>결제 시 사용할 비밀번호를 설정해주세요.</NormalTitle>
+      <div className="flex flex-col gap-10">
+        <NormalTitle>결제 시 사용될 비밀번호를 설정해주세요.</NormalTitle>
+        <div className="flex flex-col gap-10">
+          <label className="block">
+            <div className="mb-3">
+              간편 비밀번호로 사용할 숫자 6자리를 입력해주세요.
+            </div>
+            <input
+              type="password"
+              pattern="[0-9]*"
+              name="password"
+              value={inputValue}
+              onChange={updatePsw}
+              placeholder={"000000"}
+              inputMode="numeric"
+              className="mt-1 px-3 py-2 bg-white border shadow-sm border-slate-300 placeholder-slate-400 focus:outline-none focus:border-sky-500 focus:ring-sky-500 block w-full rounded-md sm:text-sm focus:ring-1"
+            />
+            {errPsw && (
+              <p className="mt-2 text-sm text-red-600">
+                {"비밀번호는 6자리 숫자로 이루어져야 합니다."}
+              </p>
+            )}
+          </label>
+          <label className="block">
+            <div className="mb-3">비밀번호를 다시 한 번 입력해주세요.</div>
+            <input
+              type="password"
+              pattern="[0-9]*"
+              name="password"
+              value={inputChkValue}
+              onChange={updateChkPsw}
+              placeholder={"000000"}
+              inputMode="numeric"
+              className="mt-1 px-3 py-2 bg-white border shadow-sm border-slate-300 placeholder-slate-400 focus:outline-none focus:border-sky-500 focus:ring-sky-500 block w-full rounded-md sm:text-sm focus:ring-1"
+            />
+            {errChkPsw && (
+              <p className="mt-2 text-sm text-red-600">
+                {"비밀번호가 일치하지 않습니다."}
+              </p>
+            )}
+          </label>
+        </div>
+      </div>
+      <ButtonBar
+        beforetext="이전"
+        nexttext="가입완료"
+        beforeurl="/confirm"
+        nexturl="/main"
+        nextdisabled={
+          errChkPsw ||
+          errPsw ||
+          password === undefined ||
+          checkPsw === undefined
+        }
+      />
     </PaddingDiv>
   );
 }

--- a/frontend/src/routes/simplepsw/SimplePage.tsx
+++ b/frontend/src/routes/simplepsw/SimplePage.tsx
@@ -1,0 +1,10 @@
+import PaddingDiv from "../../components/settingdiv/PaddingDiv";
+import NormalTitle from "../../components/text/NormalTitle";
+
+export default function SimplePage() {
+  return (
+    <PaddingDiv>
+      <NormalTitle>결제 시 사용할 비밀번호를 설정해주세요.</NormalTitle>
+    </PaddingDiv>
+  );
+}


### PR DESCRIPTION
## 🔖 PR 타입
- [x] 기능 추가

## 🌿 반영 브랜치
feat-simple-> main

## ⚒️ 구현 사항
- 결제 서비스 사용 시 입력할 간편 로그인 비밀번호 설정 페이지 구현했습니다. 
- 비밀번호를 설정 안 했을 시 다음 버튼 비활성화되게 했습니다. 
- 비밀번호가 숫자가 아니거나 6자리가 아닐 경우 다음 버튼 비활성화되게 했습니다. 
- 비밀번호를 다시 확인했을 때, 일치하지 않으면 다음 버튼 비활성화되게 했습니다 .


## ✅ 테스트 결과
<img width="338" alt="간편1" src="https://github.com/user-attachments/assets/708c47a4-9258-4fd1-8fa1-f4869d93edfd">
<img width="340" alt="간편2" src="https://github.com/user-attachments/assets/c44d2f0e-7f80-4273-9edc-ab84156da1dd">
<img width="340" alt="간편3" src="https://github.com/user-attachments/assets/a11ac4b2-ab09-4997-869e-c201d648b2a8">
<img width="339" alt="간편4" src="https://github.com/user-attachments/assets/3f8a0f42-d846-428d-b78b-362d9cfcbc87">
