### PR TITLE
feat: 아이디 중복검사 api, 전화번호 인증 api 연결

### DIFF
--- a/frontend/src/api/certificateNumberAPI.ts
+++ b/frontend/src/api/certificateNumberAPI.ts
@@ -1,0 +1,22 @@
+import BaseApi from "./axiosInstance";
+
+export interface CertificateData {
+  phoneNumber: string | null;
+}
+
+export interface ValidateCodeData {
+  phoneNumber: string | null;
+  code: string;
+}
+
+export default class certificatePhoneNumberAPI extends BaseApi {
+  async postPhoneNumber(data: CertificateData) {
+    const resp = await this.fetcher.post("/users/sms-request", data);
+    return resp;
+  }
+
+  async postCode(data: ValidateCodeData) {
+    const resp = await this.fetcher.post("/users/sms-verification", data);
+    return resp;
+  }
+}

--- a/frontend/src/api/certificateNumberAPI.ts
+++ b/frontend/src/api/certificateNumberAPI.ts
@@ -1,11 +1,11 @@
 import BaseApi from "./axiosInstance";
 
 export interface CertificateData {
-  phoneNumber: string | null;
+  phoneNumber: string | undefined;
 }
 
 export interface ValidateCodeData {
-  phoneNumber: string | null;
+  phoneNumber: string | undefined;
   code: string;
 }
 

--- a/frontend/src/api/joinAPI.ts
+++ b/frontend/src/api/joinAPI.ts
@@ -7,9 +7,18 @@ export interface JoinReqData {
   phoneNumber: string;
 }
 
+export interface IdReqData {
+  loginId: string | undefined;
+}
+
 export default class joinApi extends BaseApi {
   async postUserInfo(data: JoinReqData) {
     const resp = await this.fetcher.post("/users/signup", data);
+    return resp;
+  }
+
+  async postUserId(data: IdReqData) {
+    const resp = await this.fetcher.post("/users/validation", data);
     return resp;
   }
 }

--- a/frontend/src/routes/loginnjoin/JoinPage.tsx
+++ b/frontend/src/routes/loginnjoin/JoinPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import PaddingDiv from "../../components/settingdiv/PaddingDiv";
 import BoldTitle from "../../components/text/BoldTitle";
 import JoinButtonbar from "./component/JoinButtonbar";
@@ -14,7 +14,7 @@ export default function JoinPage() {
     ]);
   };
 
-  const [isButtonUnValid, setIsButtonUnValid] = useState<boolean>(false);
+  const [isButtonValid, setIsButtonUnValid] = useState<boolean>(false);
 
   const handleValidChange = (isValid: boolean) => {
     setIsButtonUnValid(isValid);
@@ -23,13 +23,13 @@ export default function JoinPage() {
   return (
     <PaddingDiv>
       <div>
-        <BoldTitle>안녕하세여!</BoldTitle>
+        <BoldTitle>안녕하세요!</BoldTitle>
       </div>
       <JoinInput
         onValidChange={handleValidChange}
         handleUserInfo={handleUserInfo}
       />
-      <JoinButtonbar valid={!isButtonUnValid} userInfo={userInfo} />
+      <JoinButtonbar unValid={!isButtonValid} userInfo={userInfo} />
     </PaddingDiv>
   );
 }

--- a/frontend/src/routes/loginnjoin/component/CertificateModal.tsx
+++ b/frontend/src/routes/loginnjoin/component/CertificateModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import axios from "axios";
 import NormalTitle from "../../../components/text/NormalTitle";
 import BasicModal from "../../../components/modal/BasicModal";
 import XButton from "../../../components/button/XButton";
@@ -45,11 +46,15 @@ export default function CertificateModal({
         //여기서 에러 메시지 출력하고 state 버튼 비호라성황
         setValidCode(false);
       }
-    } catch (error: any) {
-      setValidCode(false);
-      if (error.response) {
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        setValidCode(false);
         console.log("에러 발생: " + error);
       }
+      // setValidCode(false);
+      // if (error.response) {
+      //   console.log("에러 발생: " + error);
+      // }
     }
   };
 

--- a/frontend/src/routes/loginnjoin/component/CertificateModal.tsx
+++ b/frontend/src/routes/loginnjoin/component/CertificateModal.tsx
@@ -6,7 +6,7 @@ import MoveButton from "../../../components/button/MoveButton";
 import certificatePhoneNumberAPI from "../../../api/certificateNumberAPI";
 
 interface ModalProps {
-  phoneNumber: string | null;
+  phoneNumber: string | undefined;
   isModalOpen: boolean;
   handleCloseModal: () => void;
   handleCertiCheck: (value: boolean) => void;
@@ -76,7 +76,7 @@ export default function CertificateModal({
             </p>
           )}
           {validCode && (
-            <p className="mt-2 text-sm text-red-600">
+            <p className="mt-2 text-sm text-blue-600">
               {"인증이 완료되었습니다."}
             </p>
           )}

--- a/frontend/src/routes/loginnjoin/component/CertificateModal.tsx
+++ b/frontend/src/routes/loginnjoin/component/CertificateModal.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from "react";
+import NormalTitle from "../../../components/text/NormalTitle";
+import BasicModal from "../../../components/modal/BasicModal";
+import XButton from "../../../components/button/XButton";
+import MoveButton from "../../../components/button/MoveButton";
+import certificatePhoneNumberAPI from "../../../api/certificateNumberAPI";
+
+interface ModalProps {
+  phoneNumber: string | null;
+  isModalOpen: boolean;
+  handleCloseModal: () => void;
+  handleCertiCheck: (value: boolean) => void;
+}
+
+export default function CertificateModal({
+  phoneNumber,
+  isModalOpen,
+  handleCloseModal,
+  handleCertiCheck,
+}: ModalProps) {
+  const certiservice = new certificatePhoneNumberAPI();
+
+  const [code, setCode] = useState<string>("");
+  const [validCode, setValidCode] = useState<boolean | null>(null);
+
+  const updateCode = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setCode(event.target.value);
+  };
+
+  //인증코드 검증
+  const validateInputCode = async () => {
+    try {
+      const response = await certiservice.postCode({
+        phoneNumber: phoneNumber,
+        code: code,
+      });
+
+      if (response.status === 200) {
+        //여기서 버튼 비활성화 state 관리
+        setValidCode(true);
+        handleCertiCheck(true);
+        console.log((await response).data.message);
+      } else if (response.status === 400 || response.status === 500) {
+        console.log((await response).data.message);
+        //여기서 에러 메시지 출력하고 state 버튼 비호라성황
+        setValidCode(false);
+      }
+    } catch (error: any) {
+      setValidCode(false);
+      if (error.response) {
+        console.log("에러 발생: " + error);
+      }
+    }
+  };
+
+  return (
+    <BasicModal isOpen={isModalOpen} onRequestClose={handleCloseModal}>
+      <div className="flex flex-row-reverse">
+        <span onClick={handleCloseModal}>
+          <XButton />
+        </span>
+      </div>
+      <NormalTitle>
+        문자로 온 인증번호를 입력해주세요.
+        <label className="block">
+          <input
+            type="text"
+            name="code"
+            value={code}
+            onChange={updateCode}
+            className="mt-1 px-3 py-2 bg-white border shadow-sm border-slate-300 placeholder-slate-400 focus:outline-none focus:border-sky-500 focus:ring-sky-500 block w-full rounded-md sm:text-sm focus:ring-1"
+          />
+          {validCode !== null && !validCode && (
+            <p className="mt-2 text-sm text-red-600">
+              {"올바른 인증코드가 아닙니다. "}
+            </p>
+          )}
+          {validCode && (
+            <p className="mt-2 text-sm text-red-600">
+              {"인증이 완료되었습니다."}
+            </p>
+          )}
+        </label>
+        {!validCode ? (
+          <MoveButton onClick={validateInputCode}>입력완료</MoveButton>
+        ) : (
+          <MoveButton onClick={handleCloseModal}>닫기</MoveButton>
+        )}
+      </NormalTitle>
+    </BasicModal>
+  );
+}

--- a/frontend/src/routes/loginnjoin/component/CertificateModal.tsx
+++ b/frontend/src/routes/loginnjoin/component/CertificateModal.tsx
@@ -45,10 +45,12 @@ export default function CertificateModal({
         console.log((await response).data.message);
         //여기서 에러 메시지 출력하고 state 버튼 비호라성황
         setValidCode(false);
+        handleCertiCheck(false);
       }
     } catch (error) {
       if (axios.isAxiosError(error)) {
         setValidCode(false);
+        handleCertiCheck(false);
         console.log("에러 발생: " + error);
       }
       // setValidCode(false);

--- a/frontend/src/routes/loginnjoin/component/JoinButtonbar.tsx
+++ b/frontend/src/routes/loginnjoin/component/JoinButtonbar.tsx
@@ -12,7 +12,7 @@ export default function JoinButtonbar({ valid, userInfo }: ButtonProps) {
   const service = new joinApi();
   const navigate = useNavigate();
 
-  const [btnValid, setBtnValid] = useState<boolean>(true);
+  const [btnValid, setBtnValid] = useState<boolean>(false);
 
   const joinFinish = async () => {
     try {
@@ -25,30 +25,26 @@ export default function JoinButtonbar({ valid, userInfo }: ButtonProps) {
 
       if (response.status === 201) {
         //여기서 버튼 비활성화 state 관리
-        setBtnValid(false);
+        setBtnValid(true);
       } else if (response.status === 400) {
         console.log((await response).data.message);
         //여기서 에러 메시지 출력하고 state 버튼 비호라성황
-        setBtnValid(true);
+        setBtnValid(false);
       }
     } catch (error: any) {
       if (error.response) {
-        console.log("에러 발생: " + error.response.data);
+        console.log("에러 발생: " + error);
       }
     }
   };
 
-  useEffect(() => {
-    if (!valid) joinFinish();
-  }, [btnValid]);
-
   return (
     <BasicButton
       type="blue"
-      disabled={valid}
+      disabled={valid || btnValid}
       onClick={() => {
         joinFinish();
-        navigate("/mydata");
+        if (btnValid) navigate("/mydata");
       }}
     >
       다음

--- a/frontend/src/routes/loginnjoin/component/JoinButtonbar.tsx
+++ b/frontend/src/routes/loginnjoin/component/JoinButtonbar.tsx
@@ -38,13 +38,17 @@ export default function JoinButtonbar({ valid, userInfo }: ButtonProps) {
     }
   };
 
+  const moveNext = () => {
+    navigate("/mydata");
+  };
+
   return (
     <BasicButton
       type="blue"
-      disabled={valid || btnValid}
+      disabled={valid}
       onClick={() => {
         joinFinish();
-        if (btnValid) navigate("/mydata");
+        if (btnValid) moveNext();
       }}
     >
       다음

--- a/frontend/src/routes/loginnjoin/component/JoinButtonbar.tsx
+++ b/frontend/src/routes/loginnjoin/component/JoinButtonbar.tsx
@@ -1,14 +1,14 @@
 import { useNavigate } from "react-router-dom";
 import joinApi from "../../../api/joinAPI";
 import BasicButton from "../../../components/button/BasicButton";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 interface ButtonProps {
-  valid: boolean;
+  unValid: boolean;
   userInfo: string[];
 }
 
-export default function JoinButtonbar({ valid, userInfo }: ButtonProps) {
+export default function JoinButtonbar({ unValid, userInfo }: ButtonProps) {
   const service = new joinApi();
   const navigate = useNavigate();
 
@@ -45,7 +45,7 @@ export default function JoinButtonbar({ valid, userInfo }: ButtonProps) {
   return (
     <BasicButton
       type="blue"
-      disabled={valid}
+      disabled={unValid}
       onClick={() => {
         joinFinish();
         if (btnValid) moveNext();

--- a/frontend/src/routes/loginnjoin/component/JoinButtonbar.tsx
+++ b/frontend/src/routes/loginnjoin/component/JoinButtonbar.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router-dom";
 import joinApi from "../../../api/joinAPI";
 import BasicButton from "../../../components/button/BasicButton";
 import { useState } from "react";
+import axios from "axios";
 
 interface ButtonProps {
   unValid: boolean;
@@ -31,10 +32,13 @@ export default function JoinButtonbar({ unValid, userInfo }: ButtonProps) {
         //여기서 에러 메시지 출력하고 state 버튼 비호라성황
         setBtnValid(false);
       }
-    } catch (error: any) {
-      if (error.response) {
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
         console.log("에러 발생: " + error);
       }
+      // if (error.response) {
+      //   console.log("에러 발생: " + error);
+      // }
     }
   };
 

--- a/frontend/src/routes/loginnjoin/component/JoinInput.tsx
+++ b/frontend/src/routes/loginnjoin/component/JoinInput.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import certificatePhoneNumberAPI from "../../../api/certificateNumberAPI";
 import CertificateModal from "./CertificateModal";
 import joinApi from "../../../api/joinAPI";
+import axios from "axios";
 
 interface JoinProps {
   onValidChange: (isValid: boolean) => void;
@@ -89,10 +90,13 @@ export default function JoinInput({
         setIdDup(!response.data.isAvailable);
         console.log(response.data.isAvailable);
       }
-    } catch (error: any) {
-      if (error.response) {
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
         console.log("에러 발생: " + error);
       }
+      // if (error.response) {
+      //   console.log("에러 발생: " + error);
+      // }
     }
   };
 
@@ -110,10 +114,13 @@ export default function JoinInput({
         //여기서 에러 메시지 출력하고 state 버튼 비호라성황
         setErrorCerti(true);
       }
-    } catch (error: any) {
-      if (error.response) {
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
         console.log("에러 발생: " + error);
       }
+      // if (error.response) {
+      //   console.log("에러 발생: " + error);
+      // }
     }
   };
 
@@ -180,7 +187,7 @@ export default function JoinInput({
   const [valid, setValid] = useState<boolean>(false);
 
   useEffect(() => {
-    const temp: boolean =
+    const temp: boolean | null =
       !idDup &&
       dupCheck &&
       !errorPsw &&
@@ -188,7 +195,7 @@ export default function JoinInput({
       !errorPhoneNumber &&
       !errorCerti &&
       certiCheck;
-    setValid(temp);
+    if (temp !== null) setValid(temp);
   }, [
     idDup,
     dupCheck,

--- a/frontend/src/routes/loginnjoin/component/JoinInput.tsx
+++ b/frontend/src/routes/loginnjoin/component/JoinInput.tsx
@@ -24,13 +24,13 @@ export default function JoinInput({
   //비밀번호 형식이 올바른지 검사하는 함수
   const validatePassword = (password: string): boolean => {
     const passwordRegex =
-      /^(?=.*[0-9])(?=.*[!@#$%^&*(),.?":{}|<>])[a-zA-Z0-9!@#$%^&*(),.?":{}|<>]{5,}$/;
+      /^(?=.*[0-9])(?=.*[!@#$%^&*(),.?":{}|<>])[a-zA-Z0-9!@#$%^&*(),.?":{}|<>]{8,}$/;
     return passwordRegex.test(password);
   };
 
   // 전화번호 형식이 올바른지 검사하는 함수
   const validatePhoneNumber = (number: string): boolean => {
-    const phoneRegex = /^[0-9]{3}-[0-9]{4}-[0-9]{4}$/;
+    const phoneRegex = /^[0-9]{11}$/;
     return phoneRegex.test(number);
   };
 
@@ -158,7 +158,7 @@ export default function JoinInput({
           비밀번호를 입력해주세요.
         </span>
         <p className="block text-sm font-medium text-slate-700 text-gray-300">
-          비밀번호는 특수문자, 숫자를 무조건 포함하는 5자리 이상이어야 합니다.
+          비밀번호는 특수문자, 숫자를 무조건 포함하는 8자리 이상이어야 합니다.
         </p>
         <input
           type="password"
@@ -201,13 +201,15 @@ export default function JoinInput({
           name="phoneNumber"
           value={phoneNumber} // state에 저장된 전화번호를 input의 value로 설정
           onChange={handlePhoneNumber} // 입력이 변경될 때 state를 업데이트
-          pattern="[0-9]{3}-[0-9]{3}-[0-9]{4}"
+          pattern="[0-9]{11}"
           className="mt-1 px-3 py-2 bg-white border shadow-sm border-slate-300 placeholder-slate-400 focus:outline-none focus:border-sky-500 focus:ring-sky-500 block w-full rounded-md sm:text-sm focus:ring-1"
-          placeholder="000-0000-0000"
+          placeholder="00000000000"
         />
         {errorPhoneNumber && (
           <p className="mt-2 text-sm text-red-600">
-            {"전화번호 형식이 올바르지 않습니다. 형식) 000-0000-0000"}
+            {
+              "전화번호 형식이 올바르지 않습니다. - 를 제거한 숫자만 입력해주세요."
+            }
           </p>
         )}
       </label>

--- a/frontend/src/routes/loginnjoin/component/JoinInput.tsx
+++ b/frontend/src/routes/loginnjoin/component/JoinInput.tsx
@@ -75,8 +75,8 @@ export default function JoinInput({
     handleUserInfo(3, event.target.value);
   };
 
-  const handleCertiCheck = (value: boolean) => {
-    setCertiCheck(value);
+  const handleCerti = (value: boolean) => {
+    setErrorCerti(!value);
   };
 
   const checkIdDuplicate = async () => {
@@ -108,11 +108,13 @@ export default function JoinInput({
 
       if (response.status === 202) {
         //여기서 버튼 비활성화 state 관리
-        setErrorCerti(false);
+        //setErrorCerti(false);
+        openModal();
+        setCertiCheck(true);
       } else if (response.status === 400 || response.status === 500) {
         console.log((await response).data.message);
         //여기서 에러 메시지 출력하고 state 버튼 비호라성황
-        setErrorCerti(true);
+        //setErrorCerti(true);
       }
     } catch (error) {
       if (axios.isAxiosError(error)) {
@@ -126,10 +128,9 @@ export default function JoinInput({
 
   //TODO: 전화번호 인증 로직 추가
   const handleCertiPhone = () => {
-    setCertiCheck(true);
     //여기서 api 요청
     if (!errorPhoneNumber) certificatePhone();
-    if (!errorCerti) openModal();
+    //if (!errorCerti) openModal();
   };
 
   //TODO: 아이디 중복 검사 후 idDup 변경 여부 결정 & 에러 메시지 출력
@@ -196,6 +197,7 @@ export default function JoinInput({
       !errorCerti &&
       certiCheck;
     if (temp !== null) setValid(temp);
+    else if (temp === null) setValid(false);
   }, [
     idDup,
     dupCheck,
@@ -209,6 +211,13 @@ export default function JoinInput({
   useEffect(() => {
     onValidChange(valid);
   }, [valid]);
+
+  useEffect(() => {
+    console.log("전화번호 인증 여부: " + certiCheck);
+  }, [certiCheck]);
+  useEffect(() => {
+    console.log("전화번호 인증 성공: " + !errorCerti);
+  }, [errorCerti]);
 
   return (
     <div className="flex flex-col gap-10">
@@ -306,7 +315,10 @@ export default function JoinInput({
           <span className="after:content-['*'] after:ml-0.5 after:text-red-500 block text-sm font-medium text-slate-700">
             전화번호를 입력하고 인증해주세요.
           </span>
-          {certiCheck ? (
+          {errorCerti !== null &&
+          !errorCerti &&
+          certiCheck !== null &&
+          certiCheck ? (
             <p className="mt-2 text-sm text-blue-600">{"인증완료"}</p>
           ) : (
             <button
@@ -343,7 +355,7 @@ export default function JoinInput({
           errorCerti !== null &&
           certiCheck && (
             <p className="mt-2 text-sm text-red-600">
-              {"전화번호 인증 요청에 실패했습니다."}
+              {"전화번호 인증에 실패했습니다."}
             </p>
           )}
       </label>
@@ -352,7 +364,7 @@ export default function JoinInput({
           phoneNumber={phoneNumber}
           isModalOpen={isModalOpen}
           handleCloseModal={closeModal}
-          handleCertiCheck={handleCertiCheck}
+          handleCertiCheck={handleCerti}
         />
       )}
     </div>

--- a/frontend/src/routes/loginnjoin/component/LoginInput.tsx
+++ b/frontend/src/routes/loginnjoin/component/LoginInput.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 
 export default function LoginInput() {
-  const [userId, setUserId] = useState<string | null>(null);
-  const [password, setPassword] = useState<string | null>(null);
+  const [userId, setUserId] = useState<string>();
+  const [password, setPassword] = useState<string>();
 
   const handleUserId = (event: React.ChangeEvent<HTMLInputElement>) => {
     setUserId(event.target.value);

--- a/frontend/src/routes/main/MainPage.tsx
+++ b/frontend/src/routes/main/MainPage.tsx
@@ -3,12 +3,16 @@ import LargeButton from "../../components/button/LargeButton";
 import PaddingDiv from "../../components/settingdiv/PaddingDiv";
 import NormalTitle from "../../components/text/NormalTitle";
 import QRFrame from "./component/QRFrame";
-import { useState } from "react";
+//import { useState } from "react";
 
 export default function MainPage() {
   const navigate = useNavigate();
-  const [name, setName] = useState<string>("정윤현");
-  const [member, setMember] = useState<boolean>(false);
+  //TODO: 여기서 로그인시 백엔드에서 받아온 이름
+  //const [name, setName] = useState<string>("정윤현");
+  const name: string = "정윤현";
+  //TODO: 여기서 백엔드에게 받아온 가입 여부
+  //const [member, setMember] = useState<boolean>(false);
+  const member: boolean = false;
 
   return (
     <div style={{ backgroundColor: "#9abade33" }}>


### PR DESCRIPTION
## 🔖 PR 타입
- [x] 기능 추가

## 🌿 반영 브랜치
feat-joinapi -> dev

## ⚒️ 구현 사항
- 아이디 중복 검사 api 연결했습니다.
  - 중복 검사 후 아이디를 변경했을 시 중복 검사를 다시 하게 구현했습니다.
- 전화번호 인증 api 연결했습니다.
  - 전화번호 인증 후 전화번호를 변경했을 시 인증을 다시 하게 구현했습니다. 
- 아이디 중복 검사와 전화번호 인증을 안 할 시 회원가입 버튼이 비활성화되게 구현했습니다. 

## ✅ 테스트 결과
<img width="341" alt="아이디1" src="https://github.com/user-attachments/assets/a276d631-f19d-41df-971c-3be60324433a">
<img width="339" alt="아이디2" src="https://github.com/user-attachments/assets/b5dfb97e-c098-43e1-b73c-d34eae9549f3">
<img width="339" alt="전화번호1" src="https://github.com/user-attachments/assets/029cbe11-34be-436b-9190-41c38dabe7ee">
<img width="339" alt="전화번호2" src="https://github.com/user-attachments/assets/3d5ffc87-afc1-457d-95be-d84b44d23318">

