### PR TITLE
feat: 현금으로 상환, 담보주식으로 상환 페이지 구현

### DIFF
--- a/frontend/src/api/paymentAPI.ts
+++ b/frontend/src/api/paymentAPI.ts
@@ -1,8 +1,8 @@
 import BaseApi from "./axiosInstance";
 
-// export interface HistoryReqData {
-//   userId: string;
-// }
+export interface CashRepayReqData {
+  amount: number;
+}
 
 export default class paymentAPI extends BaseApi {
   async getPaymentInfo(/*data: HistoryReqData*/) {
@@ -10,8 +10,28 @@ export default class paymentAPI extends BaseApi {
     return resp;
   }
 
-  async getPaymentHistory(value: number) {
-    const resp = await this.fetcher.get(`/payment/history?month=${value}`);
+  async getPaymentHistory(y: number, m: number) {
+    const resp = await this.fetcher.get(
+      `/payment/history?year=${y}&month=${m}`
+    );
+    return resp;
+  }
+
+  //연결 계좌 정보 가져오기
+  async getRepayAccount() {
+    const resp = await this.fetcher.get("/payment/accounts");
+    return resp;
+  }
+
+  //예정 결제 금액 가져오기
+  async getRepayAmount() {
+    const resp = await this.fetcher.get("/payment/amount");
+    return resp;
+  }
+
+  //상환 금액 보내기
+  async postCashRepayAmount(data: CashRepayReqData) {
+    const resp = await this.fetcher.post("/payment/cash", data);
     return resp;
   }
 }

--- a/frontend/src/api/paymentAPI.ts
+++ b/frontend/src/api/paymentAPI.ts
@@ -34,4 +34,10 @@ export default class paymentAPI extends BaseApi {
     const resp = await this.fetcher.post("/payment/cash", data);
     return resp;
   }
+
+  //담보 주식 가져오기
+  async getMortgagedStock() {
+    const resp = await this.fetcher.get("/payment/pawn-info");
+    return resp;
+  }
 }

--- a/frontend/src/api/paymentAPI.ts
+++ b/frontend/src/api/paymentAPI.ts
@@ -4,6 +4,16 @@ export interface CashRepayReqData {
   amount: number;
 }
 
+export interface MortgagedRepayReqData {
+  repaymentAmount: number;
+  selectedStocks: {
+    stockRank: number;
+    quantity: number;
+    accountNumber: string;
+    stockCode: string;
+  }[];
+}
+
 export default class paymentAPI extends BaseApi {
   async getPaymentInfo(/*data: HistoryReqData*/) {
     const resp = await this.fetcher.get("/payment/cash-info");
@@ -38,6 +48,12 @@ export default class paymentAPI extends BaseApi {
   //담보 주식 가져오기
   async getMortgagedStock() {
     const resp = await this.fetcher.get("/payment/pawn-info");
+    return resp;
+  }
+
+  //담보로 상환하기
+  async postMortgagedRepay(data: MortgagedRepayReqData) {
+    const resp = await this.fetcher.post("/payment/pawn", data);
     return resp;
   }
 }

--- a/frontend/src/main-router.tsx
+++ b/frontend/src/main-router.tsx
@@ -17,7 +17,9 @@ import SettingDatePage from "./routes/paymentdate/SettingDatePage";
 import ConfirmPage from "./routes/confirm/ConfirmPage";
 import SimplePage from "./routes/simplepsw/SimplePage";
 import PaymentHistoryPage from "./routes/payment/PaymentHistoryPage";
+import RepayPage from "./routes/repay/RepayPage";
 import CashRepayPage from "./routes/repay/CashRePayPage";
+import MortgagedRepayPage from "./routes/repay/MortgagedRepayPage";
 
 const routers = [
   {
@@ -120,6 +122,10 @@ const routers = [
   {
     path: "/cashrepay",
     element: <CashRepayPage />,
+  },
+  {
+    path: "/mortgagedrepay",
+    element: <MortgagedRepayPage />,
   },
 ];
 

--- a/frontend/src/main-router.tsx
+++ b/frontend/src/main-router.tsx
@@ -17,6 +17,7 @@ import SettingDatePage from "./routes/paymentdate/SettingDatePage";
 import ConfirmPage from "./routes/confirm/ConfirmPage";
 import SimplePage from "./routes/simplepsw/SimplePage";
 import PaymentHistoryPage from "./routes/payment/PaymentHistoryPage";
+import CashRepayPage from "./routes/repay/CashRePayPage";
 
 const routers = [
   {
@@ -115,6 +116,10 @@ const routers = [
   {
     path: "/paymenthistory",
     element: <PaymentHistoryPage />,
+  },
+  {
+    path: "/cashrepay",
+    element: <CashRepayPage />,
   },
 ];
 

--- a/frontend/src/routes/account/SettingAccountPage.tsx
+++ b/frontend/src/routes/account/SettingAccountPage.tsx
@@ -137,9 +137,9 @@ export default function SettingAccountPage() {
           <ButtonBar
             beforetext="취소"
             nexttext="수정 완료"
-            beforeurl="/allmenu"
+            beforeurl="/payment"
             nextdisabled={!check}
-            nexturl="/allmenu"
+            nexturl="/payment"
             nextOnClick={putBankAccount}
           />
         ) : (

--- a/frontend/src/routes/allmenu/AllmenuPage.tsx
+++ b/frontend/src/routes/allmenu/AllmenuPage.tsx
@@ -6,11 +6,16 @@ import BoldTitle from "../../components/text/BoldTitle";
 import NormalTitle from "../../components/text/NormalTitle";
 import loginApi from "../../api/loginAPI";
 import { useNavigate } from "react-router-dom";
+import CashMortgagedModal from "../repay/component/CashMortgagedModal";
 
 export default function AllmenuPage() {
   const navigate = useNavigate();
   const logservice = new loginApi();
   const userservice = new userAPI();
+
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const openModal = () => setIsModalOpen(true);
+  const closeModal = () => setIsModalOpen(false);
 
   const [name, setName] = useState<string>("익명");
   const [member, setMember] = useState<boolean>(false);
@@ -103,11 +108,11 @@ export default function AllmenuPage() {
         <NormalTitle>
           <span className="text-gray-400">한도 및 상환</span>
         </NormalTitle>
-        {/*TODO: 선결제로 이동*/}
+
         <div className="ml-3 mt-3 flex flex-col gap-2">
           <div
             onClick={() => {
-              if (member) navigate("/cashrepay");
+              if (member) openModal();
             }}
           >
             <BoldTitle>선결제하기</BoldTitle>
@@ -164,6 +169,12 @@ export default function AllmenuPage() {
           </div>
         </div>
       </div>
+      {isModalOpen && (
+        <CashMortgagedModal
+          isModalOpen={isModalOpen}
+          handleCloseModal={closeModal}
+        />
+      )}
     </PaddingDiv>
   );
 }

--- a/frontend/src/routes/allmenu/AllmenuPage.tsx
+++ b/frontend/src/routes/allmenu/AllmenuPage.tsx
@@ -107,7 +107,7 @@ export default function AllmenuPage() {
         <div className="ml-3 mt-3 flex flex-col gap-2">
           <div
             onClick={() => {
-              if (member) navigate("/");
+              if (member) navigate("/cashrepay");
             }}
           >
             <BoldTitle>선결제하기</BoldTitle>

--- a/frontend/src/routes/allmenu/AllmenuPage.tsx
+++ b/frontend/src/routes/allmenu/AllmenuPage.tsx
@@ -126,7 +126,7 @@ export default function AllmenuPage() {
           </div>
           <div
             onClick={() => {
-              if (member) navigate("/limit");
+              if (member) navigate("/limit", { state: { menu: true } });
             }}
           >
             <BoldTitle>한도 변경</BoldTitle>
@@ -140,7 +140,7 @@ export default function AllmenuPage() {
           </div>
           <div
             onClick={() => {
-              if (member) navigate("/priority");
+              if (member) navigate("/priority", { state: { menu: true } });
             }}
           >
             <BoldTitle>우선순위 확인 및 변경</BoldTitle>

--- a/frontend/src/routes/payment/PaymentHistoryPage.tsx
+++ b/frontend/src/routes/payment/PaymentHistoryPage.tsx
@@ -5,25 +5,31 @@ import paymentAPI from "../../api/paymentAPI";
 import axios from "axios";
 import BoldTitle from "../../components/text/BoldTitle";
 
+type HistoryObject = {
+  id: number;
+  paymentAmount: number;
+  createdAt: string;
+  franchiseName: string;
+};
+
 export default function PaymentHistoryPage() {
   const paymentservice = new paymentAPI();
+
+  const today = new Date();
+  const [year, setYear] = useState<number>(today.getFullYear());
+  const [month, setMonth] = useState<number>(today.getMonth());
+
   //결제 아이디, 결제 금액, 결제일, 가게명
   const [paymentHistory, setPaymentHistory] = useState<
     [number, number, string, string][]
-  >([
-    [3, 1000000, "2024-08-30T00:00:00", "테슬라"],
-    [4, 2000, "2024-08-30T00:00:00", "테슬라"],
-    [5, 10000000, "2024-08-30T00:00:00", "테슬라"],
-  ]);
-  const [year, setYear] = useState<number>(0);
-  const [month, setMonth] = useState<number>(0);
-  //api 요청을 통해 결제 내역 받아오기
+  >([]);
+
   const getHistory = async () => {
     try {
-      const response = await paymentservice.getPaymentHistory(month);
+      const response = await paymentservice.getPaymentHistory(year, month);
       if (response.status === 200 || response.status === 204) {
-        const data = response.data.paymentHistories;
-        setPaymentHistory([...data]);
+        const data = response.data;
+        saveHistory(data.paymentHistories);
       }
     } catch (error) {
       if (axios.isAxiosError(error)) {
@@ -35,18 +41,23 @@ export default function PaymentHistoryPage() {
     }
   };
 
-  //밑줄 지우기 위함. 없애기.
-  useEffect(() => {
-    setYear(0);
-    setMonth(0);
-  }, []);
+  const saveHistory = (data: HistoryObject[]) => {
+    const temp: [number, number, string, string][] = data.map((item) => [
+      item.id,
+      item.paymentAmount,
+      item.createdAt,
+      item.franchiseName,
+    ]);
+    setPaymentHistory([...temp]);
+  };
+
   useEffect(() => {
     getHistory();
   }, [month]);
 
   return (
     <PaddingDiv>
-      <div className="place-items-center">
+      <div>
         <NormalTitle>결제 내역</NormalTitle>
       </div>
       <div>

--- a/frontend/src/routes/payment/PaymentPage.tsx
+++ b/frontend/src/routes/payment/PaymentPage.tsx
@@ -7,10 +7,15 @@ import NormalTitle from "../../components/text/NormalTitle";
 import MoveButton from "../../components/button/MoveButton";
 import userAPI from "../../api/userAPI";
 import axios from "axios";
+import CashMortgagedModal from "../repay/component/CashMortgagedModal";
 
 export default function PaymentPage() {
   const userservice = new userAPI();
   const navigate = useNavigate();
+
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const openModal = () => setIsModalOpen(true);
+  const closeModal = () => setIsModalOpen(false);
 
   //TODO: 여기서 백엔드에게 이름과 가입 여부 가져오기
   const [name, setName] = useState<string>("익명");
@@ -72,9 +77,7 @@ export default function PaymentPage() {
         </div>
         {memeber && (
           <div className="h-100 grid grid-cols-2 gap-5">
-            <MoveButton onClick={() => navigate("/cashrepay")}>
-              선결제
-            </MoveButton>
+            <MoveButton onClick={openModal}>선결제</MoveButton>
             <MoveButton onClick={() => navigate("/limit")}>
               한도 변경
             </MoveButton>
@@ -87,6 +90,12 @@ export default function PaymentPage() {
           </div>
         )}
       </PaddingDiv>
+      {isModalOpen && (
+        <CashMortgagedModal
+          isModalOpen={isModalOpen}
+          handleCloseModal={closeModal}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/routes/payment/PaymentPage.tsx
+++ b/frontend/src/routes/payment/PaymentPage.tsx
@@ -78,7 +78,9 @@ export default function PaymentPage() {
         {memeber && (
           <div className="h-100 grid grid-cols-2 gap-5">
             <MoveButton onClick={openModal}>선결제</MoveButton>
-            <MoveButton onClick={() => navigate("/limit")}>
+            <MoveButton
+              onClick={() => navigate("/limit", { state: { menu: true } })}
+            >
               한도 변경
             </MoveButton>
             <MoveButton onClick={() => navigate("/stock")}>

--- a/frontend/src/routes/payment/PaymentPage.tsx
+++ b/frontend/src/routes/payment/PaymentPage.tsx
@@ -72,7 +72,9 @@ export default function PaymentPage() {
         </div>
         {memeber && (
           <div className="h-100 grid grid-cols-2 gap-5">
-            <MoveButton onClick={() => navigate("/")}>선결제</MoveButton>
+            <MoveButton onClick={() => navigate("/cashrepay")}>
+              선결제
+            </MoveButton>
             <MoveButton onClick={() => navigate("/limit")}>
               한도 변경
             </MoveButton>

--- a/frontend/src/routes/priority/PriorityPage.tsx
+++ b/frontend/src/routes/priority/PriorityPage.tsx
@@ -8,6 +8,7 @@ import SetPriorityModal from "./component/SetPriorityModal";
 import payServiceAPI from "../../api/payServiceAPI";
 import axios from "axios";
 import userAPI from "../../api/userAPI";
+import { useLocation } from "react-router-dom";
 
 type mortgagedObject = {
   accountNumber: string;
@@ -37,6 +38,10 @@ type priorityObject = {
 export default function PriorityPage() {
   const payjoinservice = new payServiceAPI();
   const userservice = new userAPI();
+
+  const location = useLocation();
+  // 전달된 state를 받아옵니다. (default 값을 false로 설정)
+  const { menu } = location.state || { menu: false };
 
   const [mem, setMem] = useState<boolean>(false);
 
@@ -481,13 +486,25 @@ export default function PriorityPage() {
 
       <div className="mt-auto">
         {mem ? (
-          <ButtonBar
-            beforetext="이전"
-            nexttext="다음"
-            beforeurl="/allmenu"
-            nexturl="/limit"
-            nextOnClick={putPriority}
-          />
+          <div>
+            {menu ? (
+              <ButtonBar
+                beforetext="이전"
+                nexttext="수정 완료"
+                beforeurl="/allmenu"
+                nexturl="/allmenu"
+                nextOnClick={putPriority}
+              />
+            ) : (
+              <ButtonBar
+                beforetext="이전"
+                nexttext="다음"
+                beforeurl="/stock"
+                nexturl="/limit"
+                nextOnClick={putPriority}
+              />
+            )}
+          </div>
         ) : (
           <ButtonBar
             beforetext="이전"

--- a/frontend/src/routes/priority/PriorityPage.tsx
+++ b/frontend/src/routes/priority/PriorityPage.tsx
@@ -482,10 +482,10 @@ export default function PriorityPage() {
       <div className="mt-auto">
         {mem ? (
           <ButtonBar
-            beforetext="취소"
-            nexttext="수정 완료"
+            beforetext="이전"
+            nexttext="다음"
             beforeurl="/allmenu"
-            nexturl="/allmenu"
+            nexturl="/limit"
             nextOnClick={putPriority}
           />
         ) : (

--- a/frontend/src/routes/repay/CashRepayPage.tsx
+++ b/frontend/src/routes/repay/CashRepayPage.tsx
@@ -108,43 +108,50 @@ export default function CashRepayPage() {
         <div>
           {companyName} {accountNumber}
         </div>
+        <div>계좌 잔고: {accountMoney.toLocaleString()}원</div>
       </BackgroundFrame>
-      <NormalTitle>결제 예정 금액</NormalTitle>
-      <BackgroundFrame color="blue">
-        <div>{totalDebt.toLocaleString()}원</div>
-        <div>
-          {previousMonth === 12 ? (
-            <span>{today.getFullYear() - 1}</span>
-          ) : (
-            <span>{today.getFullYear()}</span>
-          )}
-          년 {previousMonth}월 결제 {previousMonthDebt.toLocaleString()}원
-        </div>
-        <div>
-          {today.getFullYear()}년 {currentMonth}월 결제{" "}
-          {currentMonthDebt.toLocaleString()}원
-        </div>
-      </BackgroundFrame>
-      <NormalTitle>결제할 금액 입력</NormalTitle>
-      <BackgroundFrame color="blue">
-        <label className="block">
-          <span className="text-sm text-gray-400">
+      <div>
+        <NormalTitle>결제 예정 금액</NormalTitle>
+        <BackgroundFrame color="blue">
+          <div>{totalDebt.toLocaleString()}원</div>
+          <div>
+            {previousMonth === 12 ? (
+              <span>{today.getFullYear() - 1}</span>
+            ) : (
+              <span>{today.getFullYear()}</span>
+            )}
+            년 {previousMonth}월 결제 {previousMonthDebt.toLocaleString()}원
+          </div>
+          <div>
+            {today.getFullYear()}년 {currentMonth}월 결제{" "}
+            {currentMonthDebt.toLocaleString()}원
+          </div>
+        </BackgroundFrame>
+      </div>
+
+      <div>
+        <NormalTitle>결제할 금액 입력</NormalTitle>
+        <BackgroundFrame color="blue">
+          <label className="block">
+            {/* <span className="text-sm text-gray-400">
             최대 {accountMoney.toLocaleString()}원 입력 가능합니다.
-          </span>
-          <input
-            type="number"
-            name="repay"
-            value={inputValue}
-            onChange={handleTempSelected}
-            className="mt-1 px-3 py-2 bg-white border shadow-sm border-slate-300 placeholder-slate-400 focus:outline-none focus:border-sky-500 focus:ring-sky-500 block w-full rounded-md sm:text-sm focus:ring-1"
-          />
-          {errInput && inputValue.length > 0 && (
-            <p className="mt-2 text-sm text-red-600">
-              {"계좌 잔액 이하의 금액을 입력해주세요."}
-            </p>
-          )}
-        </label>
-      </BackgroundFrame>
+          </span> */}
+            <input
+              type="number"
+              name="repay"
+              value={inputValue}
+              onChange={handleTempSelected}
+              className="mt-1 px-3 py-2 bg-white border shadow-sm border-slate-300 placeholder-slate-400 focus:outline-none focus:border-sky-500 focus:ring-sky-500 block w-full rounded-md sm:text-sm focus:ring-1"
+            />
+            {errInput && inputValue.length > 0 && (
+              <p className="mt-2 text-sm text-red-600">
+                {"계좌 잔액 이하의 금액을 입력해주세요."}
+              </p>
+            )}
+          </label>
+        </BackgroundFrame>
+      </div>
+
       <div className="mt-auto">
         <ButtonBar
           beforetext="취소"

--- a/frontend/src/routes/repay/CashRepayPage.tsx
+++ b/frontend/src/routes/repay/CashRepayPage.tsx
@@ -17,7 +17,9 @@ export default function CashRepayPage() {
   const [repaymentDate, setRepaymentDate] = useState<number>(1);
   const [previousMonthDebt, setPreviousMonthDebt] = useState<number>(0);
   const [currentMonthDebt, setCurrentMonthDebt] = useState<number>(0);
-  const [currentMonth, setCurrentMonth] = useState<number>(today.getMonth());
+  const [currentMonth, setCurrentMonth] = useState<number>(
+    (today.getMonth() + 1) % 12
+  );
   const [previousMonth, setPreviousMonth] = useState<number>(0);
   const [totalDebt, setTotalDebt] = useState<number>(0);
 
@@ -26,7 +28,7 @@ export default function CashRepayPage() {
   const [repayAmount, setRepayAmount] = useState<number>(0);
 
   useEffect(() => {
-    if (today.getMonth() !== 1) {
+    if (currentMonth !== 1) {
       setPreviousMonth(currentMonth - 1);
     } else setPreviousMonth(12);
   }, []);

--- a/frontend/src/routes/repay/CashRepayPage.tsx
+++ b/frontend/src/routes/repay/CashRepayPage.tsx
@@ -85,7 +85,7 @@ export default function CashRepayPage() {
   }, [previousMonthDebt, currentMonthDebt]);
 
   const validateInput = (ip: number) => {
-    if (ip > accountMoney /* || ip > totalDebt */ || ip <= 0) {
+    if (ip > accountMoney || ip > totalDebt || ip <= 0) {
       setErrInput(true);
     } else {
       setRepayAmount(ip);
@@ -148,7 +148,7 @@ export default function CashRepayPage() {
             />
             {errInput && inputValue.length > 0 && (
               <p className="mt-2 text-sm text-red-600">
-                {"계좌 잔액 이하의 금액을 입력해주세요."}
+                {"계좌 잔액, 결제 예정 금액 이하로 입력해주세요."}
               </p>
             )}
           </label>

--- a/frontend/src/routes/repay/CashRepayPage.tsx
+++ b/frontend/src/routes/repay/CashRepayPage.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from "react";
+import BackgroundFrame from "../../components/backgroundframe/BackgroundFrame";
+import PaddingDiv from "../../components/settingdiv/PaddingDiv";
+import BoldTitle from "../../components/text/BoldTitle";
+import paymentAPI from "../../api/paymentAPI";
+import NormalTitle from "../../components/text/NormalTitle";
+import ButtonBar from "../../components/button/ButtonBar";
+
+export default function CashRepayPage() {
+  const repayservice = new paymentAPI();
+
+  const today = new Date();
+
+  const [companyName, setCompanyName] = useState<string>("신한은행");
+  const [accountNumber, setAccountNumber] = useState<string>("0000-0000");
+  const [accountMoney, setAccountMoney] = useState<number>(1000000);
+  const [repaymentDate, setRepaymentDate] = useState<number>(1);
+  const [previousMonthDebt, setPreviousMonthDebt] = useState<number>(0);
+  const [currentMonthDebt, setCurrentMonthDebt] = useState<number>(0);
+  const [currentMonth, setCurrentMonth] = useState<number>(today.getMonth());
+  const [previousMonth, setPreviousMonth] = useState<number>(0);
+  const [totalDebt, setTotalDebt] = useState<number>(0);
+
+  const [inputValue, setInputValue] = useState<string>("");
+  const [errInput, setErrInput] = useState<boolean>(true);
+  const [repayAmount, setRepayAmount] = useState<number>(0);
+
+  useEffect(() => {
+    if (today.getMonth() !== 1) {
+      setPreviousMonth(currentMonth - 1);
+    } else setPreviousMonth(12);
+  }, []);
+
+  const getAccountInfo = async () => {
+    try {
+      const response = await repayservice.getRepayAccount();
+
+      if (response.status === 200) {
+        //setCompanyName(response.data.companyName);
+        setAccountNumber(response.data.accountNumber);
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  const getRepayAmount = async () => {
+    try {
+      const response = await repayservice.getRepayAmount();
+
+      if (response.status === 200) {
+        setRepaymentDate(response.data.repaymentDate);
+        setPreviousMonthDebt(response.data.previousMonthDebt);
+        setCurrentMonthDebt(response.data.currentMonthDebt);
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  const postCashRepayAmount = async (): Promise<boolean> => {
+    try {
+      const temp = { amount: repayAmount };
+      const response = await repayservice.postCashRepayAmount(temp);
+
+      if (response.status === 200) {
+        return true;
+      } else return false;
+    } catch (error) {
+      console.log(error);
+      return false;
+    }
+  };
+
+  useEffect(() => {
+    getAccountInfo();
+    getRepayAmount();
+  }, []);
+
+  useEffect(() => {
+    setTotalDebt(previousMonthDebt + currentMonthDebt);
+  }, [previousMonthDebt, currentMonthDebt]);
+
+  const validateInput = (ip: number) => {
+    if (ip > accountMoney /* || ip > totalDebt */ || ip <= 0) {
+      setErrInput(true);
+    } else {
+      setRepayAmount(ip);
+      setErrInput(false);
+    }
+  };
+
+  const handleTempSelected = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    const valueToNum = Number(value);
+
+    if (value === "" || !isNaN(Number(value))) {
+      setInputValue(value);
+      validateInput(valueToNum);
+    }
+  };
+
+  return (
+    <PaddingDiv>
+      <BoldTitle>즉시 상환 하기</BoldTitle>
+      <BackgroundFrame color="blue">
+        <div>140pay 결제일 {repaymentDate}일</div>
+        <div>
+          {companyName} {accountNumber}
+        </div>
+      </BackgroundFrame>
+      <NormalTitle>결제 예정 금액</NormalTitle>
+      <BackgroundFrame color="blue">
+        <div>{totalDebt.toLocaleString()}원</div>
+        <div>
+          {previousMonth === 12 ? (
+            <span>{today.getFullYear() - 1}</span>
+          ) : (
+            <span>{today.getFullYear()}</span>
+          )}
+          년 {previousMonth}월 결제 {previousMonthDebt.toLocaleString()}원
+        </div>
+        <div>
+          {today.getFullYear()}년 {currentMonth}월 결제{" "}
+          {currentMonthDebt.toLocaleString()}원
+        </div>
+      </BackgroundFrame>
+      <NormalTitle>결제할 금액 입력</NormalTitle>
+      <BackgroundFrame color="blue">
+        <label className="block">
+          <span className="text-sm text-gray-400">
+            최대 {accountMoney.toLocaleString()}원 입력 가능합니다.
+          </span>
+          <input
+            type="number"
+            name="repay"
+            value={inputValue}
+            onChange={handleTempSelected}
+            className="mt-1 px-3 py-2 bg-white border shadow-sm border-slate-300 placeholder-slate-400 focus:outline-none focus:border-sky-500 focus:ring-sky-500 block w-full rounded-md sm:text-sm focus:ring-1"
+          />
+          {errInput && inputValue.length > 0 && (
+            <p className="mt-2 text-sm text-red-600">
+              {"계좌 잔액 이하의 금액을 입력해주세요."}
+            </p>
+          )}
+        </label>
+      </BackgroundFrame>
+      <div className="mt-auto">
+        <ButtonBar
+          beforetext="취소"
+          beforeurl="/payment"
+          nexttext="상환하기"
+          nexturl="/payment"
+          nextdisabled={errInput}
+          nextOnClick={postCashRepayAmount}
+        />
+      </div>
+    </PaddingDiv>
+  );
+}

--- a/frontend/src/routes/repay/CashRepayPage.tsx
+++ b/frontend/src/routes/repay/CashRepayPage.tsx
@@ -38,8 +38,9 @@ export default function CashRepayPage() {
       const response = await repayservice.getRepayAccount();
 
       if (response.status === 200) {
-        //setCompanyName(response.data.companyName);
+        setCompanyName(response.data.accountName);
         setAccountNumber(response.data.accountNumber);
+        setAccountMoney(response.data.accountDeposit);
       }
     } catch (error) {
       console.log(error);

--- a/frontend/src/routes/repay/MortgagedRepayPage.tsx
+++ b/frontend/src/routes/repay/MortgagedRepayPage.tsx
@@ -135,6 +135,10 @@ export default function MortgagedRepayPage() {
   };
 
   useEffect(() => {
+    validateInput(repayAmount);
+  }, [sellStockPrice]);
+
+  useEffect(() => {
     getRepayAmount();
   }, []);
 

--- a/frontend/src/routes/repay/MortgagedRepayPage.tsx
+++ b/frontend/src/routes/repay/MortgagedRepayPage.tsx
@@ -1,0 +1,342 @@
+import { useEffect, useState } from "react";
+import PaddingDiv from "../../components/settingdiv/PaddingDiv";
+import BoldTitle from "../../components/text/BoldTitle";
+import paymentAPI from "../../api/paymentAPI";
+import NormalTitle from "../../components/text/NormalTitle";
+import BackgroundFrame from "../../components/backgroundframe/BackgroundFrame";
+import ButtonBar from "../../components/button/ButtonBar";
+
+type MortgagedObject = {
+  stockRank: number;
+  accountNumber: string;
+  quantity: number;
+  stockCode: string;
+  stockName: string;
+  companyCode: string;
+  companyName: string;
+  stabilityLevel: number;
+  presentValue: number;
+  limitPrice: number;
+  percent: number;
+};
+
+export default function MortgagedRepayPage() {
+  const repayservice = new paymentAPI();
+
+  const today = new Date();
+
+  const [inputValue, setInputValue] = useState<string>("");
+  const [errInput, setErrInput] = useState<boolean>(true);
+  const [repayAmount, setRepayAmount] = useState<number>(0);
+
+  const [repaymentDate, setRepaymentDate] = useState<number>(1);
+  const [previousMonthDebt, setPreviousMonthDebt] = useState<number>(0);
+  const [currentMonthDebt, setCurrentMonthDebt] = useState<number>(0);
+  const [currentMonth, setCurrentMonth] = useState<number>(today.getMonth());
+  const [previousMonth, setPreviousMonth] = useState<number>(0);
+  const [totalDebt, setTotalDebt] = useState<number>(0);
+
+  //length: 11
+  //0: 우선순위, 1: 계좌번호, 2: 수량, 3: 종목코드, 4: 종목명, 5: 증권사코드, 6: 증권사명
+  //7: 위험도, 8: 전일종가, 9: 한도, 10: 퍼센트
+  const [mortgagedStock, setMortgagedStock] = useState<
+    [
+      number,
+      string,
+      number,
+      string,
+      string,
+      string,
+      string,
+      number,
+      number,
+      number,
+      number
+    ][]
+  >([]);
+
+  const [sellStock, setSellStock] = useState<
+    [
+      number,
+      string,
+      number,
+      string,
+      string,
+      string,
+      string,
+      number,
+      number,
+      number,
+      number
+    ][]
+  >([]);
+  const [sellStockPrice, setSellStockPrice] = useState<number>(0);
+
+  useEffect(() => {
+    if (today.getMonth() !== 1) {
+      setPreviousMonth(currentMonth - 1);
+    } else setPreviousMonth(12);
+  }, []);
+
+  const getRepayAmount = async () => {
+    try {
+      const response = await repayservice.getRepayAmount();
+
+      if (response.status === 200) {
+        setRepaymentDate(response.data.repaymentDate);
+        setPreviousMonthDebt(response.data.previousMonthDebt);
+        setCurrentMonthDebt(response.data.currentMonthDebt);
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  useEffect(() => {
+    getRepayAmount();
+  }, []);
+
+  const getMortgagedStock = async () => {
+    try {
+      const response = await repayservice.getMortgagedStock();
+
+      if (response.status === 200) {
+        saveMortgagedStock(response.data.stockPriorities);
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  useEffect(() => {
+    getMortgagedStock();
+  }, []);
+
+  const saveMortgagedStock = (data: MortgagedObject[]) => {
+    const temp: [
+      number,
+      string,
+      number,
+      string,
+      string,
+      string,
+      string,
+      number,
+      number,
+      number,
+      number
+    ][] = data.map((item) => [
+      item.stockRank,
+      item.accountNumber,
+      item.quantity,
+      item.stockCode,
+      item.stockName,
+      item.companyCode,
+      item.companyName,
+      item.stabilityLevel,
+      item.presentValue,
+      item.limitPrice,
+      item.percent,
+    ]);
+
+    setMortgagedStock([...temp]);
+  };
+
+  const selectSellStock = (
+    row: [
+      number,
+      string,
+      number,
+      string,
+      string,
+      string,
+      string,
+      number,
+      number,
+      number,
+      number
+    ]
+  ) => {
+    mortgagedStock.forEach((rowA) => {
+      // 우선 배열에 일치하는 행이 있는지 검사
+      const isMatch = sellStock.some(
+        (rowB) =>
+          rowA[1] === rowB[1] && rowA[2] === rowB[2] && rowA[3] === rowB[3]
+      );
+
+      if (!isMatch) setSellStock((prevState) => [...prevState, row]);
+    });
+  };
+
+  const deleteSellStock = (rowIndex: number) => {
+    console.log("삭제");
+    setSellStock((prevState) =>
+      prevState.filter((_, index) => index !== rowIndex)
+    );
+  };
+
+  useEffect(() => {
+    setTotalDebt(previousMonthDebt + currentMonthDebt);
+  }, [previousMonthDebt, currentMonthDebt]);
+
+  useEffect(() => {
+    let limit = 0;
+    sellStock.map((row) => {
+      limit += row[2] * row[8];
+    });
+    setSellStockPrice(limit);
+  }, [sellStock]);
+
+  const validateInput = (ip: number) => {
+    if (ip > sellStockPrice /* || ip > totalDebt */ || ip <= 0) {
+      setErrInput(true);
+    } else {
+      setRepayAmount(ip);
+      setErrInput(false);
+    }
+  };
+
+  const handleTempSelected = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    const valueToNum = Number(value);
+
+    if (value === "" || !isNaN(Number(value))) {
+      setInputValue(value);
+      validateInput(valueToNum);
+    }
+  };
+
+  return (
+    <PaddingDiv>
+      <BoldTitle>담보주식으로 상환 하기</BoldTitle>
+      <div>
+        <NormalTitle>매도할 종목을 클릭하고 주수를 선택해주세요.</NormalTitle>
+        <BackgroundFrame color="blue">
+          <div className="text-xs">
+            <table
+              style={{
+                width: "100%",
+                borderCollapse: "collapse",
+                textAlign: "center",
+              }}
+            >
+              <thead>
+                <tr>
+                  <th>증권사명</th>
+                  <th>종목명</th>
+                  <th>선택 주수</th>
+                  <th>전일 종가</th>
+                  {/* <th>등급</th> */}
+                  <th>가능 한도</th>
+                </tr>
+              </thead>
+              <tbody>
+                {mortgagedStock.map((stock) => (
+                  <tr onClick={() => selectSellStock(stock)}>
+                    <td>{stock[6]}</td>
+                    <td>{stock[4]}</td>
+                    <td>{stock[2]}</td>
+                    <td>{stock[8].toLocaleString()}</td>
+                    {/* <td>{stock[7]}</td> */}
+                    <td>{stock[9].toLocaleString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </BackgroundFrame>
+      </div>
+
+      <div>
+        <NormalTitle>선택한 주식</NormalTitle>
+        <BackgroundFrame color="blue">
+          <div className="text-xs">
+            <table
+              style={{
+                width: "100%",
+                borderCollapse: "collapse",
+                textAlign: "center",
+              }}
+            >
+              <thead>
+                <tr>
+                  <th>증권사명</th>
+                  <th>종목명</th>
+                  <th>선택 주수</th>
+                  <th>전일 종가</th>
+                  {/* <th>등급</th> */}
+                  <th>가능 한도</th>
+                  <th>삭제</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sellStock.map((stock, index) => (
+                  <tr>
+                    <td>{stock[6]}</td>
+                    <td>{stock[4]}</td>
+                    <td>{stock[2]}</td>
+                    <td>{stock[8].toLocaleString()}</td>
+                    {/* <td>{stock[7]}</td> */}
+                    <td>{stock[9].toLocaleString()}</td>
+                    <td onClick={() => deleteSellStock(index)}>-</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </BackgroundFrame>
+      </div>
+      <div>
+        <NormalTitle>결제 예정 금액</NormalTitle>
+        <BackgroundFrame color="blue">
+          <div>{totalDebt.toLocaleString()}원</div>
+          <div>
+            {previousMonth === 12 ? (
+              <span>{today.getFullYear() - 1}</span>
+            ) : (
+              <span>{today.getFullYear()}</span>
+            )}
+            년 {previousMonth}월 결제 {previousMonthDebt.toLocaleString()}원
+          </div>
+          <div>
+            {today.getFullYear()}년 {currentMonth}월 결제{" "}
+            {currentMonthDebt.toLocaleString()}원
+          </div>
+        </BackgroundFrame>
+      </div>
+      <div>
+        <NormalTitle>
+          결제 가능 금액: {sellStockPrice.toLocaleString()}원
+        </NormalTitle>
+        <label className="block">
+          {/* <span className="text-sm text-gray-400">
+            최대 {accountMoney.toLocaleString()}원 입력 가능합니다.
+          </span> */}
+          <input
+            type="number"
+            name="repay"
+            value={inputValue}
+            onChange={handleTempSelected}
+            className="mt-1 px-3 py-2 bg-white border shadow-sm border-slate-300 placeholder-slate-400 focus:outline-none focus:border-sky-500 focus:ring-sky-500 block w-full rounded-md sm:text-sm focus:ring-1"
+          />
+          {errInput && inputValue.length > 0 && (
+            <p className="mt-2 text-sm text-red-600">
+              {"계좌 잔액 이하의 금액을 입력해주세요."}
+            </p>
+          )}
+        </label>
+      </div>
+
+      <div className="mt-auto">
+        <ButtonBar
+          beforetext="취소"
+          beforeurl="/payment"
+          nexttext="상환하기"
+          nexturl="/payment"
+          nextdisabled={errInput}
+          //nextOnClick={postCashRepayAmount}
+        />
+      </div>
+    </PaddingDiv>
+  );
+}

--- a/frontend/src/routes/repay/component/AlertRepayModal.tsx
+++ b/frontend/src/routes/repay/component/AlertRepayModal.tsx
@@ -1,0 +1,47 @@
+import BasicModal from "../../../components/modal/BasicModal";
+import XButton from "../../../components/button/XButton";
+import { useNavigate } from "react-router-dom";
+
+interface ModalProps {
+  isAlertOpen: boolean;
+  handleCloseAlert: () => void;
+  result: {
+    repaymentAmount: number;
+    totalSellAmount: number;
+    realRepaymentAmount: number;
+    amountToAccount: number;
+    message: string;
+  };
+}
+
+export default function AlertRepayModal({
+  isAlertOpen,
+  handleCloseAlert,
+  result,
+}: ModalProps) {
+  const navigate = useNavigate();
+  return (
+    <BasicModal isOpen={isAlertOpen} onRequestClose={handleCloseAlert}>
+      <div className="flex flex-row-reverse">
+        <span
+          onClick={() => {
+            handleCloseAlert();
+            navigate("/payment");
+          }}
+        >
+          <XButton />
+        </span>
+      </div>
+      <div>
+        실시간 종가에 따라, {result.realRepaymentAmount.toLocaleString()}원
+        상환되었습니다.
+      </div>
+      {result.amountToAccount > 0 && (
+        <div>
+          상환 후 남은 {result.amountToAccount.toLocaleString()}원이 연결된
+          계좌로 입금됐습니다.
+        </div>
+      )}
+    </BasicModal>
+  );
+}

--- a/frontend/src/routes/repay/component/CashMortgagedModal.tsx
+++ b/frontend/src/routes/repay/component/CashMortgagedModal.tsx
@@ -1,0 +1,41 @@
+import { useNavigate } from "react-router-dom";
+import MoveButton from "../../../components/button/MoveButton";
+import XButton from "../../../components/button/XButton";
+import BasicModal from "../../../components/modal/BasicModal";
+
+interface ModalProps {
+  isModalOpen: boolean;
+  handleCloseModal: () => void;
+}
+
+export default function CashMortgagedModal({
+  isModalOpen,
+  handleCloseModal,
+}: ModalProps) {
+  const navigate = useNavigate();
+  return (
+    <BasicModal isOpen={isModalOpen} onRequestClose={handleCloseModal}>
+      <div className="flex flex-row-reverse">
+        <span onClick={handleCloseModal}>
+          <XButton />
+        </span>
+      </div>
+      <div className="flex flex-col gap-5 ">
+        <MoveButton
+          onClick={() => {
+            navigate("/cashrepay");
+          }}
+        >
+          은행 계좌로 선결제
+        </MoveButton>
+        <MoveButton
+          onClick={() => {
+            navigate("/mortgagedrepay");
+          }}
+        >
+          담보 주식으로 선결제
+        </MoveButton>
+      </div>
+    </BasicModal>
+  );
+}

--- a/frontend/src/routes/repay/component/SellStockModal.tsx
+++ b/frontend/src/routes/repay/component/SellStockModal.tsx
@@ -1,0 +1,116 @@
+import { useState } from "react";
+import XButton from "../../../components/button/XButton";
+import BasicModal from "../../../components/modal/BasicModal";
+import MoveButton from "../../../components/button/MoveButton";
+
+interface ModalProps {
+  isModalOpen: boolean;
+  handleCloseModal: () => void;
+  clickedRow:
+    | [
+        number,
+        string,
+        number,
+        string,
+        string,
+        string,
+        string,
+        number,
+        number,
+        number,
+        number
+      ];
+  selectSellStock: (
+    row:
+      | [
+          number,
+          string,
+          number,
+          string,
+          string,
+          string,
+          string,
+          number,
+          number,
+          number,
+          number
+        ],
+    value: number
+  ) => void;
+}
+
+export default function SellStockModal({
+  isModalOpen,
+  handleCloseModal,
+  clickedRow,
+  selectSellStock,
+}: ModalProps) {
+  const [inputValue, setInputValue] = useState<string>("");
+  const [errInput, setErrInput] = useState<boolean>(true);
+
+  const [selectedAmount, setSelectedAmount] = useState<number>(0);
+
+  const validateInput = (ip: number) => {
+    if (ip > clickedRow[2] /* || ip > totalDebt */ || ip <= 0) {
+      setErrInput(true);
+    } else {
+      setSelectedAmount(ip);
+      setErrInput(false);
+    }
+  };
+
+  const handleTempSelected = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    const valueToNum = Number(value);
+
+    if (value === "" || !isNaN(Number(value))) {
+      setInputValue(value);
+      validateInput(valueToNum);
+    }
+  };
+
+  return (
+    <BasicModal isOpen={isModalOpen} onRequestClose={handleCloseModal}>
+      <div className="flex flex-row-reverse">
+        <span onClick={handleCloseModal}>
+          <XButton />
+        </span>
+      </div>
+      <label className="block">
+        <span className="text-sm text-gray-400">
+          최대 {clickedRow[2]}주 선택 가능합니다.
+        </span>
+        <input
+          type="number"
+          name="repay"
+          value={inputValue}
+          onChange={handleTempSelected}
+          className="mt-1 px-3 py-2 bg-white border shadow-sm border-slate-300 placeholder-slate-400 focus:outline-none focus:border-sky-500 focus:ring-sky-500 block w-full rounded-md sm:text-sm focus:ring-1"
+        />
+        {errInput && inputValue.length > 0 && (
+          <p className="mt-2 text-sm text-red-600">
+            {`0 이상 ${clickedRow[2]} 이하로 입력해주세요.`}
+          </p>
+        )}
+      </label>
+      {errInput ? (
+        <MoveButton
+          onClick={() => {
+            handleCloseModal();
+          }}
+        >
+          닫기
+        </MoveButton>
+      ) : (
+        <MoveButton
+          onClick={() => {
+            selectSellStock(clickedRow, selectedAmount);
+            handleCloseModal();
+          }}
+        >
+          완료
+        </MoveButton>
+      )}
+    </BasicModal>
+  );
+}

--- a/frontend/src/routes/settinglimit/SettingLimitPage.tsx
+++ b/frontend/src/routes/settinglimit/SettingLimitPage.tsx
@@ -145,9 +145,9 @@ export default function SettingLimitPage() {
           <ButtonBar
             beforetext="취소"
             nexttext="수정 완료"
-            beforeurl="/allmenu"
+            beforeurl="/payment"
             nextdisabled={errLimit}
-            nexturl="/allmenu"
+            nexturl="/payment"
             //nextOnClick={putMorgagedStocks}
           />
         ) : (

--- a/frontend/src/routes/settinglimit/SettingLimitPage.tsx
+++ b/frontend/src/routes/settinglimit/SettingLimitPage.tsx
@@ -8,10 +8,15 @@ import ButtonBar from "../../components/button/ButtonBar";
 import payServiceAPI from "../../api/payServiceAPI";
 import axios from "axios";
 import userAPI from "../../api/userAPI";
+import { useLocation } from "react-router-dom";
 
 export default function SettingLimitPage() {
   const userservice = new userAPI();
   const payjoinservice = new payServiceAPI();
+
+  const location = useLocation();
+  // 전달된 state를 받아옵니다. (default 값을 false로 설정)
+  const { menu } = location.state || { menu: false };
 
   const [mem, setMem] = useState<boolean>(false);
 
@@ -142,14 +147,26 @@ export default function SettingLimitPage() {
 
       <div className="mt-auto">
         {mem ? (
-          <ButtonBar
-            beforetext="취소"
-            nexttext="수정 완료"
-            beforeurl="/payment"
-            nextdisabled={errLimit}
-            nexturl="/payment"
-            //nextOnClick={putMorgagedStocks}
-          />
+          <div>
+            {menu ? (
+              <ButtonBar
+                beforetext="취소"
+                nexttext="수정 완료"
+                beforeurl="/payment"
+                nexturl="/payment"
+                //nextOnClick={putMorgagedStocks}
+              />
+            ) : (
+              <ButtonBar
+                beforetext="이전"
+                nexttext="수정 완료"
+                beforeurl="/priority"
+                nextdisabled={errLimit}
+                nexturl="/payment"
+                //nextOnClick={putMorgagedStocks}
+              />
+            )}
+          </div>
         ) : (
           <ButtonBar
             beforetext="이전"

--- a/frontend/src/routes/stock/StockPage.tsx
+++ b/frontend/src/routes/stock/StockPage.tsx
@@ -413,9 +413,9 @@ export default function StockPage() {
               {mem ? (
                 <ButtonBar
                   beforetext="취소"
-                  nexttext="수정 완료"
-                  beforeurl="/allmenu"
-                  nexturl="/allmenu"
+                  nexttext="다음"
+                  beforeurl="/payment"
+                  nexturl="/priority"
                   nextOnClick={putMorgagedStocks}
                 />
               ) : (


### PR DESCRIPTION
## 🔖 PR 타입
- [x] 기능 추가

## 🌿 반영 브랜치
feat-pay -> main

## ⚒️ 구현 사항
- 현금으로 선결제하는 페이지 구현했습니다.
- 담보주식 매도로 선결제하는 페이지 구현했습니다. 

## ✅ 테스트 결과
<img width="300" alt="결제1" src="https://github.com/user-attachments/assets/4100613d-1466-43ac-ac14-a629aa36a6d6">
<img width="301" alt="결제2" src="https://github.com/user-attachments/assets/932527e0-e5dc-4a30-9bf3-b0709cd5d6bd">
<img width="299" alt="결제3" src="https://github.com/user-attachments/assets/a7b868d4-edcf-410b-9fc3-6004216e964d">
<img width="298" alt="결제4" src="https://github.com/user-attachments/assets/bf35241b-b731-4bc3-95fb-97e88d34b064">
<img width="301" alt="결제5" src="https://github.com/user-attachments/assets/677928eb-47fe-4486-b13c-bdef0c6db39f">

