### PR TITLE
fix: 자산페이지 증권 자세히 보기 모달 창 스크롤 추가

### DIFF
--- a/frontend/src/routes/asset/StockDetailModal.tsx
+++ b/frontend/src/routes/asset/StockDetailModal.tsx
@@ -6,7 +6,7 @@ interface StockDetailModalProps {
 
 export default function StockDetailModal(props: StockDetailModalProps) {
   return (
-    <div className="bg-white h-full">
+    <div className="bg-white h-[35vh]">
       <div className="grid grid-cols-6 gap-1 text-[10px] mb-3">
         <p className="col-span-1 truncate">증권사</p>
         <p className="col-span-1 truncate">종목명</p>


### PR DESCRIPTION
## 🔖 PR 타입
- [] 기능 추가
- [x] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트


## 🌿 반영 브랜치
fix/자산페이지-증권-자세히-보기-모달-창-스크롤 추가 -> dev

## ⚒️ 구현 사항
자산페이지의 담보 증권, 담보로 잡지 않은 증권 자세히 보기 모달 창의 높이 제한을 두고 스크롤을 추가했습니다.

## ✅ 테스트 결과
![image](https://github.com/user-attachments/assets/1dbfa7b7-0a39-4130-bc12-c56376a0683d)
