### PR TITLE
Fix/자산페이지 서비스미가입 차단

### DIFF
--- a/frontend/src/routes/asset/AssetPage.tsx
+++ b/frontend/src/routes/asset/AssetPage.tsx
@@ -18,25 +18,12 @@ interface checkMem {
 export default function AssetPage() {
   const service = new userAPI();
   const [name, setName] = useState<string>("익명");
-  const navigate = useNavigate();
 
   const getUserInfo = async () => {
     try {
       const response = await service.checkMem();
 
       if (response.status === 200) {
-        const data: checkMem = response.data;
-
-        if (!data.paymentServiceMember) {
-          Swal.fire({
-            icon: "warning",
-            title: `<span style="font-size: 20px; font-weight : bolder;">결제 서비스에<br/>가입하지 않으셨습니다.</span>`,
-            confirmButtonColor: "blue",
-          }).then(() => {
-            navigate(-1);
-          });
-        }
-
         setName(response.data.name);
       }
     } catch (error) {

--- a/frontend/src/routes/asset/AssetPage.tsx
+++ b/frontend/src/routes/asset/AssetPage.tsx
@@ -5,16 +5,38 @@ import MortgageState from "./MortgageState";
 
 import axios from "axios";
 import StockPieChart from "./StockPieChart";
+import Swal from "sweetalert2";
+import { useNavigate } from "react-router-dom";
+
+interface checkMem {
+  name: string;
+  paymentAccess: boolean;
+  paymentServiceMember: boolean;
+  userId: string;
+}
 
 export default function AssetPage() {
   const service = new userAPI();
   const [name, setName] = useState<string>("익명");
+  const navigate = useNavigate();
 
   const getUserInfo = async () => {
     try {
       const response = await service.checkMem();
 
       if (response.status === 200) {
+        const data: checkMem = response.data;
+
+        if (!data.paymentServiceMember) {
+          Swal.fire({
+            icon: "warning",
+            title: `<span style="font-size: 20px; font-weight : bolder;">결제 서비스에<br/>가입하지 않으셨습니다.</span>`,
+            confirmButtonColor: "blue",
+          }).then(() => {
+            navigate(-1);
+          });
+        }
+
         setName(response.data.name);
       }
     } catch (error) {

--- a/frontend/src/routes/asset/AssetPage.tsx
+++ b/frontend/src/routes/asset/AssetPage.tsx
@@ -5,15 +5,6 @@ import MortgageState from "./MortgageState";
 
 import axios from "axios";
 import StockPieChart from "./StockPieChart";
-import Swal from "sweetalert2";
-import { useNavigate } from "react-router-dom";
-
-interface checkMem {
-  name: string;
-  paymentAccess: boolean;
-  paymentServiceMember: boolean;
-  userId: string;
-}
 
 export default function AssetPage() {
   const service = new userAPI();

--- a/frontend/src/routes/asset/CollateralRatioGraph.tsx
+++ b/frontend/src/routes/asset/CollateralRatioGraph.tsx
@@ -47,6 +47,8 @@ export default function CollateralRatioGraph() {
 
     const data: getHistoryI[] = res.data;
 
+    let maxMortgage = 0;
+
     data.map((value) => {
       asset.data.push(value.mortgageSum);
       limit.data.push(value.todayLimit);
@@ -54,6 +56,8 @@ export default function CollateralRatioGraph() {
       xLabels.push(
         value.createdAt.split("-")[1] + "-" + value.createdAt.split("-")[2]
       );
+
+      maxMortgage = Math.max(maxMortgage, value.mortgageSum);
     });
 
     console.log(s);
@@ -99,6 +103,7 @@ export default function CollateralRatioGraph() {
       },
       yaxis: [
         {
+          show: maxMortgage === 0 ? false : true,
           title: {
             text: "(만원)",
           },

--- a/frontend/src/routes/asset/CollateralRatioGraph.tsx
+++ b/frontend/src/routes/asset/CollateralRatioGraph.tsx
@@ -51,6 +51,9 @@ export default function CollateralRatioGraph() {
       asset.data.push(value.mortgageSum);
       limit.data.push(value.todayLimit);
       minimum.data.push(value.maxLimit * 1.4);
+      xLabels.push(
+        value.createdAt.split("-")[1] + "-" + value.createdAt.split("-")[2]
+      );
     });
 
     console.log(s);

--- a/frontend/src/routes/asset/StockDetailModal.tsx
+++ b/frontend/src/routes/asset/StockDetailModal.tsx
@@ -6,7 +6,7 @@ interface StockDetailModalProps {
 
 export default function StockDetailModal(props: StockDetailModalProps) {
   return (
-    <div className="bg-white h-full">
+    <div className="bg-white h-[35vh]">
       <div className="grid grid-cols-6 gap-1 text-[10px] mb-3">
         <p className="col-span-1 truncate">증권사</p>
         <p className="col-span-1 truncate">종목명</p>


### PR DESCRIPTION
## 🔖 PR 타입
- [] 기능 추가
- [x] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트


## 🌿 반영 브랜치
ex) feat/자산페이지-서비스미가입-차단 -> main

## ⚒️ 구현 사항
신규 유저라서 담보유지비율 기록이 없어 그래프에 데이터가 그려지지 않아 y축 라벨이 깨지는 오류를 수정했습니다.
(기록이 없는 경우 y축 라벨을 숨김)

## ✅ 테스트 결과
![image](https://github.com/user-attachments/assets/13f83e5a-69d0-4659-9174-cbb77f78cdb7)